### PR TITLE
adding flash support for stm8l051f3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Support table
 | stm8s105 |  ok   |  FAIL  |  no  |  ok    |  ok     |  no   |
 | stm8s208 |  ?    |  ?     |  no  |  ?     |  ?      |  no   |
 | stm8l150 |  ok   |  FAIL  |  no  |  ok    |  ok     |  no   |
+|stm8l051f3|  ok   |  ?     |  ?   |  ?     |  ?      |  ?    |
 
 Legend:
 

--- a/stm8.c
+++ b/stm8.c
@@ -42,7 +42,7 @@ stm8_device_t stm8_devices[] = {
 	  .flash_size = 8*1024,
       .flash_block_size = 64,
 	  REGS_STM8S
-	 },
+	},
 	{
 	  .name = "stm8s105",
 	  .ram_start = 0x0000,
@@ -53,7 +53,7 @@ stm8_device_t stm8_devices[] = {
 	  .flash_size = 16*1024,
       .flash_block_size = 128,
 	  REGS_STM8S
-	 },
+	},
 	{
 	  .name = "stm8s208",
 	  .ram_start = 0x0000,
@@ -64,7 +64,7 @@ stm8_device_t stm8_devices[] = {
 	  .flash_size = 32*1024,
       .flash_block_size = 128,
 	  REGS_STM8S
-	 },
+	},
 	{
 	  .name = "stm8l150",
 	  .ram_start = 0x0000,
@@ -75,6 +75,17 @@ stm8_device_t stm8_devices[] = {
 	  .flash_size = 32*1024,
       .flash_block_size = 128,
 	  REGS_STM8L
-	 },
+	},
+	{
+		.name = "stm8l051f3",
+		.ram_start = 0x0000,
+		.ram_size = 1*1024,
+		.eeprom_start = 0x1000,
+		.eeprom_size = 256,
+		.flash_start = 0x8000,
+		.flash_size = 8*1024,
+		.flash_block_size = 64,
+		REGS_STM8L
+	},
 	{ NULL },
 };


### PR DESCRIPTION
Hi,
would you accept this patch? It will add flash support for the stm8l051f3 devices. I've tested it with the latest version of stm8flash under OS/X.

cheers,
Torsten