### PR TITLE
Added support to read/write OPT bytes on stlinkv2

### DIFF
--- a/main.c
+++ b/main.c
@@ -240,7 +240,9 @@ int main(int argc, char **argv) {
                 fprintf(stderr, "Determine FLASH area\r\n");
 				break;
 			case OPT:
-                start = 0x4800;
+                if(!start_addr_specified) {
+                    start = 0x4800;
+                }
                 size_t opt_size = (part->flash_size == 8*1024 ? 0x40 : 0x80);
                 if(!bytes_count_specified || bytes_count > opt_size) {
                     bytes_count = opt_size;

--- a/main.c
+++ b/main.c
@@ -241,8 +241,9 @@ int main(int argc, char **argv) {
 				break;
 			case OPT:
                 start = 0x4800;
-                if(!bytes_count_specified || bytes_count > 0x80) {
-                    bytes_count = 0x80;
+                size_t opt_size = (part->flash_size == 8*1024 ? 0x40 : 0x80);
+                if(!bytes_count_specified || bytes_count > opt_size) {
+                    bytes_count = opt_size;
                 }
                 break;
 		}

--- a/main.c
+++ b/main.c
@@ -194,6 +194,9 @@ int main(int argc, char **argv) {
 
     // Try define memory type by address
 	if(memtype == UNKNOWN) {
+        if((start >= 0x4800) && (start < 0x4880)) {
+            memtype = OPT;
+        }
         if((start >= part->ram_start) && (start < part->ram_start + part->ram_size)) {
             memtype = RAM;
         }
@@ -236,6 +239,12 @@ int main(int argc, char **argv) {
                 }
                 fprintf(stderr, "Determine FLASH area\r\n");
 				break;
+			case OPT:
+                start = 0x4800;
+                if(!bytes_count_specified || bytes_count > part->flash_size) {
+                    bytes_count = 0x80;
+                }
+                break;
 		}
 		start_addr_specified = true;
 	}

--- a/main.c
+++ b/main.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
                 if(!start_addr_specified) {
                     start = 0x4800;
                 }
-                size_t opt_size = (part->flash_size == 8*1024 ? 0x40 : 0x80);
+                size_t opt_size = (part->flash_size <= 8*1024 ? 0x40 : 0x80);
                 if(!bytes_count_specified || bytes_count > opt_size) {
                     bytes_count = opt_size;
                 }

--- a/main.c
+++ b/main.c
@@ -241,7 +241,7 @@ int main(int argc, char **argv) {
 				break;
 			case OPT:
                 start = 0x4800;
-                if(!bytes_count_specified || bytes_count > part->flash_size) {
+                if(!bytes_count_specified || bytes_count > 0x80) {
                     bytes_count = 0x80;
                 }
                 break;

--- a/main.c
+++ b/main.c
@@ -245,6 +245,7 @@ int main(int argc, char **argv) {
                 if(!bytes_count_specified || bytes_count > opt_size) {
                     bytes_count = opt_size;
                 }
+                fprintf(stderr, "Determine OPT area\r\n");
                 break;
 		}
 		start_addr_specified = true;

--- a/stlinkv2.c
+++ b/stlinkv2.c
@@ -235,7 +235,7 @@ int stlink2_swim_write_range(programmer_t *pgm, stm8_device_t *device, unsigned 
 	for(i = 0; i < length; i+=BLOCK_SIZE) {
         if(memtype == FLASH || memtype == EEPROM) {
             // block programming mode
-            stlink2_write_byte(pgm, 0x01, device->regs.FLASH_CR2); // mov 0x01, FLASH_CR2; 0x817e - enable write OPT bytes
+            stlink2_write_byte(pgm, 0x01, device->regs.FLASH_CR2); // mov 0x01fe, FLASH_CR2; 0x817e - enable write OPT bytes
             if(device->regs.FLASH_NCR2 != 0) { // Device have FLASH_NCR2 register
                 stlink2_write_byte(pgm, 0xFE, device->regs.FLASH_NCR2);
             }

--- a/stlinkv2.c
+++ b/stlinkv2.c
@@ -216,6 +216,7 @@ int stlink2_swim_write_range(programmer_t *pgm, stm8_device_t *device, unsigned 
         stlink2_write_and_read_byte(pgm, 0x00, device->regs.FLASH_IAPSR);
     }
 
+    // Unlock MASS
     if(memtype == FLASH) {
         stlink2_write_byte(pgm, 0x56, device->regs.FLASH_PUKR);
         stlink2_write_byte(pgm, 0xae, device->regs.FLASH_PUKR); 
@@ -232,27 +233,42 @@ int stlink2_swim_write_range(programmer_t *pgm, stm8_device_t *device, unsigned 
 	int i;
 	int BLOCK_SIZE = device->flash_block_size;
 	for(i = 0; i < length; i+=BLOCK_SIZE) {
-        if(memtype == FLASH || memtype == EEPROM || memtype == OPT) {
-            // stlink2_write_word(pgm, 0x01fe, device->regs.FLASH_CR2); // mov 0x01fe, FLASH_CR2
-            stlink2_write_byte(pgm, 0x01, device->regs.FLASH_CR2); // mov 0x01fe, FLASH_CR2; 0x817e - enable write OPT bytes
+        if(memtype == FLASH || memtype == EEPROM) {
+            // block programming mode
+            stlink2_write_byte(pgm, 0x01, device->regs.FLASH_CR2); // mov 0x01, FLASH_CR2; 0x817e - enable write OPT bytes
             if(device->regs.FLASH_NCR2 != 0) { // Device have FLASH_NCR2 register
                 stlink2_write_byte(pgm, 0xFE, device->regs.FLASH_NCR2);
             }
+        } else if (memtype == OPT){
+            // option programming mode
+            stlink2_write_byte(pgm, 0x80, device->regs.FLASH_CR2);
+            if(device->regs.FLASH_NCR2 != 0) {
+                stlink2_write_byte(pgm, 0x7F, device->regs.FLASH_NCR2);
+            }
         }
 
-		// The first 8 packet bytes are getting transmitted
-		// with the same USB bulk transfer as the command itself
-		msg_init(cmd_buf, 0xf40a);
-		format_int(&(cmd_buf[2]), BLOCK_SIZE, 2, MP_BIG_ENDIAN);
-		format_int(&(cmd_buf[6]), start + i, 2, MP_BIG_ENDIAN);
-		memcpy(&(cmd_buf[8]), &(buffer[i]), 8);
-		msg_send(pgm, cmd_buf, sizeof(cmd_buf));
+        if(memtype == OPT){
+            int j;
+            for(j = 0; j < length; j++){
+                stlink2_write_byte(pgm, buffer[j], start+j);
+                TRY(8, HI(stlink2_get_status(pgm)) == 1);
+            }
+        } else {
+            // page-based writing
+            // The first 8 packet bytes are getting transmitted
+            // with the same USB bulk transfer as the command itself
+            msg_init(cmd_buf, 0xf40a);
+            format_int(&(cmd_buf[2]), BLOCK_SIZE, 2, MP_BIG_ENDIAN);
+            format_int(&(cmd_buf[6]), start + i, 2, MP_BIG_ENDIAN);
+            memcpy(&(cmd_buf[8]), &(buffer[i]), 8);
+            msg_send(pgm, cmd_buf, sizeof(cmd_buf));
 
-		// Transmitting the rest
-		msg_send(pgm, &(buffer[i + 8]), BLOCK_SIZE - 8);
+            // Transmitting the rest
+            msg_send(pgm, &(buffer[i + 8]), BLOCK_SIZE - 8);
 
-		// Waiting for the transfer to process
-		TRY(128, HI(stlink2_get_status(pgm)) == BLOCK_SIZE);
+            // Waiting for the transfer to process
+            TRY(128, HI(stlink2_get_status(pgm)) == BLOCK_SIZE);
+        }
 
         if(memtype == FLASH || memtype == EEPROM || memtype == OPT) {
             stlink2_wait_until_transfer_completes(pgm, device);


### PR DESCRIPTION
This works for me on my stm8s005k6 device to read/write option bytes including the ROP byte (OPT0).