### PR TITLE
Add support for all current STM8S devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ stm8flash -c <stlink|stlinkv2> -p <partname> [-s flash|eeprom|0x8000] [-r|-w|-v]
 
 Flash samples:
 ```nohighlight
-./stm8flash -c stlink -p stm8s003 -w blinky.bin
-./stm8flash -c stlink -p stm8s003 -w blinky.ihx
-./stm8flash -c stlinkv2 -p stm8s003 -w blinky.ihx
-./stm8flash -c stlink -p stm8s105 -w blinky.bin
+./stm8flash -c stlink -p stm8s003f3 -w blinky.bin
+./stm8flash -c stlink -p stm8s003f3 -w blinky.ihx
+./stm8flash -c stlinkv2 -p stm8s003f3 -w blinky.ihx
+./stm8flash -c stlink -p stm8s105c6 -w blinky.bin
 ./stm8flash -c stlinkv2 -p stm8l150 -w blinky.bin
 ```
 
 EEPROM samples:
 ```nohighlight
-./stm8flash -c stlinkv2 -p stm8s003 -s eeprom -r ee.bin
-./stm8flash -c stlinkv2 -p stm8s003 -s eeprom -w ee.bin
-./stm8flash -c stlinkv2 -p stm8s003 -s eeprom -v ee.bin
+./stm8flash -c stlinkv2 -p stm8s003f3 -s eeprom -r ee.bin
+./stm8flash -c stlinkv2 -p stm8s003f3 -s eeprom -w ee.bin
+./stm8flash -c stlinkv2 -p stm8s003f3 -s eeprom -v ee.bin
 ```
 
 Support table
@@ -35,20 +35,38 @@ Support table
   * ST-Link V1: flash/eeprom/opt
   * ST-Link V2: flash2/eeprom2/opt2
 
-| MCU      | flash | eeprom | opt  | flash2 | eeprom2 | opt2  |
-|----------|-------|--------|------|--------|---------|-------|
-| stm8s003 |  ok   |  FAIL  |  ?   |  ok    |  ok     |  ?    |
-| stm8s103 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
-| stm8s105 |  ok   |  FAIL  |  ?   |  ok    |  ok     |  ?    |
-| stm8s208 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
-| stm8l150 |  ok   |  FAIL  |  ?   |  ok    |  ok     |  ?    |
-|stm8l051f3|  ok   |  ?     |  ?   |  ?     |  ?      |  ?    |
-|stm8s005k6|  ok   |  ?     |  ok  |  ?     |  ?      |  ?    |
+| MCU        | flash | eeprom | opt  | flash2 | eeprom2 | opt2  |
+|------------|-------|--------|------|--------|---------|-------|
+| stm8l051f3 |  ok   |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8l150   |  ok   |  FAIL  |  ?   |  ok    |  ok     |  ?    |
+| stm8s003?3 |  ok   |  FAIL  |  ?   |  ok    |  ok     |  ?    |
+| stm8s005?6 |  ok   |  ?     |  ok  |  ?     |  ?      |  ?    |
+| stm8s007c8 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s103f2 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s103?3 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s105?4 |  ok   |  FAIL  |  ?   |  ok    |  ok     |  ?    |
+| stm8s105?6 |  ?    |  ?     |  ?   |  ok    |  ?      |  ?    |
+| stm8s207c8 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s207cb |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s207k8 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s207m8 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s207mb |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s207r8 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s207rb |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s207s8 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s207sb |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s207?6 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s208c6 |  ?    |  ?     |  ?   |  ok    |  ?      |  ?    |
+| stm8s208s6 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s208?8 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s208?b |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8s903?3 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
+| stm8splnb1 |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
 
 Legend:
 
-  * `ok` - full supported
-  * `no` - not supported now
-  * `?` - not tested
-  * `fail` - not work. Need fix
+  * `ok`   - Fully supported.
+  * `no`   - Not supported now.
+  * `?`    - Not tested.
+  * `FÁIL` - Not working. Needs fix.
 

--- a/main.c
+++ b/main.c
@@ -116,6 +116,19 @@ bool usb_init(programmer_t *pgm, unsigned int vid, unsigned int pid) {
 	return(true);
 }
 
+stm8_device_t *get_part(const char *name)
+{
+	for(unsigned int i = 0; stm8_devices[i].name; i++)
+	{
+		const char *e = stm8_devices[i].name;
+		const char *s = name;
+		for(e = stm8_devices[i].name, s = name; *s && (*e == *s || *e == '?'); e++, s++);
+		if(!*e)
+			return(&stm8_devices[i]);
+	}
+	return(0);
+}
+
 int main(int argc, char **argv) {
 	int start, bytes_count = 0;
 	char filename[256];
@@ -142,10 +155,7 @@ int main(int argc, char **argv) {
 				break;
 			case 'p':
 				part_specified = true;
-				for(i = 0; stm8_devices[i].name; i++) {
-					if(!strcmp(optarg, stm8_devices[i].name))
-						part = &stm8_devices[i];
-				}
+				part = get_part(optarg);
 				break;
 			case 'l':
 				for(i = 0; stm8_devices[i].name; i++)

--- a/stm8.c
+++ b/stm8.c
@@ -22,59 +22,15 @@
 
 stm8_device_t stm8_devices[] = {
     {
-        .name = "stm8s003",
+        .name = "stm8l051f3",
         .ram_start = 0x0000,
         .ram_size = 1*1024,
-        .eeprom_start = 0x4000,
-        .eeprom_size = 128,
+        .eeprom_start = 0x1000,
+        .eeprom_size = 256,
         .flash_start = 0x8000,
         .flash_size = 8*1024,
         .flash_block_size = 64,
-        REGS_STM8S
-    },
-    {
-        .name = "stm8s005k6",
-        .ram_start = 0x0000,
-        .ram_size = 2*1024,
-        .eeprom_start = 0x4000,
-        .eeprom_size = 128,
-        .flash_start = 0x8000,
-        .flash_size = 32*1024,
-        .flash_block_size = 128,
-        REGS_STM8S
-    },
-    {
-        .name = "stm8s103",
-        .ram_start = 0x0000,
-        .ram_size = 1*1024,
-        .eeprom_start = 0x4000,
-        .eeprom_size = 640,
-        .flash_start = 0x8000,
-        .flash_size = 8*1024,
-        .flash_block_size = 64,
-        REGS_STM8S
-    },
-    {
-        .name = "stm8s105",
-        .ram_start = 0x0000,
-        .ram_size = 2*1024,
-        .eeprom_start = 0x4000,
-        .eeprom_size = 1024,
-        .flash_start = 0x8000,
-        .flash_size = 16*1024,
-        .flash_block_size = 128,
-        REGS_STM8S
-    },
-    {
-        .name = "stm8s208",
-        .ram_start = 0x0000,
-        .ram_size = 6*1024,
-        .eeprom_start = 0x4000,
-        .eeprom_size = 2048,
-        .flash_start = 0x8000,
-        .flash_size = 32*1024,
-        .flash_block_size = 128,
-        REGS_STM8S
+        REGS_STM8L
     },
     {
         .name = "stm8l101f1",
@@ -110,15 +66,258 @@ stm8_device_t stm8_devices[] = {
         REGS_STM8L
     },
     {
-        .name = "stm8l051f3",
+        .name = "stm8s003?3",
         .ram_start = 0x0000,
         .ram_size = 1*1024,
-        .eeprom_start = 0x1000,
-        .eeprom_size = 256,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 128,
         .flash_start = 0x8000,
         .flash_size = 8*1024,
         .flash_block_size = 64,
-        REGS_STM8L
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s005?6",
+        .ram_start = 0x0000,
+        .ram_size = 2*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 128,
+        .flash_start = 0x8000,
+        .flash_size = 32*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s007c8",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 128,
+        .flash_start = 0x8000,
+        .flash_size = 64*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s103f2",
+        .ram_start = 0x0000,
+        .ram_size = 1*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 640,
+        .flash_start = 0x8000,
+        .flash_size = 4*1024,
+        .flash_block_size = 64,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s103?3",
+        .ram_start = 0x0000,
+        .ram_size = 1*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 640,
+        .flash_start = 0x8000,
+        .flash_size = 8*1024,
+        .flash_block_size = 64,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s105?4",
+        .ram_start = 0x0000,
+        .ram_size = 2*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 1024,
+        .flash_start = 0x8000,
+        .flash_size = 16*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s105?6",
+        .ram_start = 0x0000,
+        .ram_size = 2*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 1024,
+        .flash_start = 0x8000,
+        .flash_size = 32*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s207c8",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 1536,
+        .flash_start = 0x8000,
+        .flash_size = 64*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s207cb",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 2048,
+        .flash_start = 0x8000,
+        .flash_size = 128*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s207k8",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 1024,
+        .flash_start = 0x8000,
+        .flash_size = 64*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s207m8",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 2048,
+        .flash_start = 0x8000,
+        .flash_size = 64*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s207mb",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 2048,
+        .flash_start = 0x8000,
+        .flash_size = 128*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s207r8",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 1536,
+        .flash_start = 0x8000,
+        .flash_size = 64*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s207rb",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 2048,
+        .flash_start = 0x8000,
+        .flash_size = 128*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s207s8",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 1536,
+        .flash_start = 0x8000,
+        .flash_size = 64*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s207sb",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 1536,
+        .flash_start = 0x8000,
+        .flash_size = 128*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s207?6",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 1024,
+        .flash_start = 0x8000,
+        .flash_size = 32*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s208c6",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 2048,
+        .flash_start = 0x8000,
+        .flash_size = 32*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s208s6",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 1536,
+        .flash_start = 0x8000,
+        .flash_size = 32*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s208?8",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 2048,
+        .flash_start = 0x8000,
+        .flash_size = 64*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s208?b",
+        .ram_start = 0x0000,
+        .ram_size = 6*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 2048,
+        .flash_start = 0x8000,
+        .flash_size = 128*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8s903?3",
+        .ram_start = 0x0000,
+        .ram_size = 1*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 640,
+        .flash_start = 0x8000,
+        .flash_size = 8*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
+    },
+    {
+        .name = "stm8splnb1",
+        .ram_start = 0x0000,
+        .ram_size = 1*1024,
+        .eeprom_start = 0x4000,
+        .eeprom_size = 640,
+        .flash_start = 0x8000,
+        .flash_size = 8*1024,
+        .flash_block_size = 128,
+        REGS_STM8S
     },
     { NULL },
 };
+


### PR DESCRIPTION
Support for all STM8S devices.
Some STM8 differ only in ways not relevant to stm8flash. To keep the list of supported devices short, a wildcard character '?' has been introduced.
Choice of wildcard character: '?' is reasonably known as wildcard. ST documentation uses 'x' as wildcard. But stm8flash uses lowercase for part names, and some STM8 devices contain 'X' in the part name.
For the list of devices in README.md, I copied the existing results to the closest matching part. I did a quick flash2 test on stm8s105c6 myself.

Philipp
