### PR TITLE
fixes to allows compiling under windows (mingw-w64-i686)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,41 @@
-.PHONY: all clean
-OBJECTS=stlink.o stlinkv2.o main.o byte_utils.o ihex.o stm8.o
-CFLAGS = `pkg-config --cflags libusb-1.0` -g -O0 --std=gnu99 --pedantic
+# stm8flash makefile
+#
+# Multiplatform support
+#   - Linux (x86, Raspian)
+#   - MacOS (Darwin)
+#   - Windows (e.g. mingw-w64-x86 with libusb1.0)
+
+
 PLATFORM=$(shell uname -s)
-ifeq ($(PLATFORM),Darwin)
-  MacOSSDK=`xcrun --show-sdk-path`
-  CFLAGS += -I$(MacOSSDK)/usr/include/ -I$(MacOSSDK)/usr/include/sys -I$(MacOSSDK)/usr/include/machine
+
+ifeq ($(PLATFORM),Linux)
+	LIBS = `pkg-config --libs libusb-1.0`
+	CFLAGS = `pkg-config --cflags libusb-1.0` -g -O0 --std=gnu99 --pedantic
+else ifeq ($(PLATFORM),Darwin)
+	LIBS = `pkg-config --libs libusb-1.0`
+	CFLAGS = `pkg-config --cflags libusb-1.0` -g -O0 --std=gnu99 --pedantic
+  	MacOSSDK=`xcrun --show-sdk-path`
+  	CFLAGS += -I$(MacOSSDK)/usr/include/ -I$(MacOSSDK)/usr/include/sys -I$(MacOSSDK)/usr/include/machine
+else 
+# 	Generic case is Windows
+
+	LIBS   = -lusb-1.0
+	CFLAGS = -g -O0 --std=gnu99 --pedantic 
+	CC	   = GCC
+	BIN_SUFFIX =.exe
 endif
-LIBS = `pkg-config --libs libusb-1.0`
-BIN = stm8flash
+
+BIN 		=stm8flash
+OBJECTS 	=stlink.o stlinkv2.o main.o byte_utils.o ihex.o stm8.o
+
+
+.PHONY: all clean
 
 all: $(OBJECTS)
 	$(CC) $(OBJECTS) $(LIBS) -o $(BIN)
 
 clean:
-	-rm -f $(OBJECTS) $(BIN)
+	-rm -f $(OBJECTS) $(BIN)$(BIN_SUFFIX)
 
 install:
-	cp $(BIN) $(DESTDIR)/usr/bin/
+	cp $(BIN)$(BIN_SUFFIX) $(DESTDIR)/usr/bin/

--- a/error.h
+++ b/error.h
@@ -1,3 +1,8 @@
+
+
+// Fixes warning
+#undef ERROR
+
 #define ERROR(s) do { fprintf(stderr, "%s\n", (s)); exit(-1); } while(0)
 #define ERROR2(...) do { fprintf(stderr, __VA_ARGS__); exit(-1); } while(0)
 #define PERROR(s) do { perror((s)); exit(-1); } while(0)

--- a/main.c
+++ b/main.c
@@ -102,7 +102,7 @@ bool usb_init(programmer_t *pgm, unsigned int vid, unsigned int pid) {
 		assert(r == 0);
 	}
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(WIN32)
 	r = libusb_claim_interface(pgm->dev_handle, 0);
 	assert(r == 0);
 #endif

--- a/pgm.h
+++ b/pgm.h
@@ -1,7 +1,13 @@
 #ifndef __PGM_H
 #define __PGM_H
 
-#include <libusb.h>
+#ifndef WIN32
+ #include <endian.h>
+ #include <libusb.h>
+#else
+ #include <libusb-1.0/libusb.h>
+#endif
+
 #include "stm8.h"
 
 typedef enum {

--- a/stlink.c
+++ b/stlink.c
@@ -3,18 +3,21 @@
 
 #include <stdio.h>
 #include <stddef.h>
-#include <libusb.h>
+
 #include <malloc.h>
 #include <assert.h>
 #include <string.h>
 #include <stdbool.h>
 #include <stdarg.h>
-#include <endian.h>
 #include <unistd.h>
 #include "stm8.h"
 #include "pgm.h"
 #include "stlink.h"
 #include "utils.h"
+
+#ifndef WIN32
+#include <endian.h>
+#endif
 
 #define STLK_FLAG_ERR 0x01
 #define STLK_FLAG_BUFFER_FULL 0x04

--- a/stlink.h
+++ b/stlink.h
@@ -5,7 +5,6 @@
 #define __STLINK_H
 
 #include <stdio.h>
-#include <libusb.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include "pgm.h"


### PR DESCRIPTION
I finally managed to compile the tool under windows as well. A couple of changes where required in the makefile and for some includes.

Please use mingw-w64-i686 (standalone or as part of MSYS2) to compile.

