### PR TITLE
Added Extended Segment Address and Extended Linear Address records to…

### DIFF
--- a/ihex.c
+++ b/ihex.c
@@ -23,7 +23,7 @@ static unsigned char checksum(unsigned char *buf, unsigned int length, int chunk
 
 int ihex_read(FILE *pFile, unsigned char *buf, unsigned int start, unsigned int end) {
 	fseek(pFile, 0, SEEK_SET);
-	unsigned int chunk_len, chunk_addr, chunk_type, i, byte, line_no = 0, greatest_addr = 0;
+	unsigned int chunk_len, chunk_addr, chunk_type, i, byte, line_no = 0, greatest_addr = 0, offset = 0;
 	while(fgets(line, sizeof(line), pFile)) {
 		line_no++;
 		// Reading chunk header
@@ -32,6 +32,25 @@ int ihex_read(FILE *pFile, unsigned char *buf, unsigned int start, unsigned int 
 			ERROR2("Error while parsing IHEX at line %d\n", line_no);
 		}
 		// Reading chunk data
+		if(chunk_type == 2) // Extended Segment Address
+		{
+			unsigned int esa;
+			if(sscanf(&line[9],"%04x",&esa) != 1) {
+				free(buf);
+				ERROR2("Error while parsing IHEX at line %d\n", line_no);
+			}
+			offset = esa * 16;
+		}
+		if(chunk_type == 4) // Extended Linear Address
+		{
+			unsigned int ela;
+			if(sscanf(&line[9],"%04x",&ela) != 1) {
+				free(buf);
+				ERROR2("Error while parsing IHEX at line %d\n", line_no);
+			}
+			offset = ela * 65536;
+		}
+		
 		for(i = 9; i < strlen(line) - 1; i +=2) {
 			if(sscanf(&(line[i]), "%02x", &byte) != 1) {
 				free(buf);
@@ -45,18 +64,18 @@ int ihex_read(FILE *pFile, unsigned char *buf, unsigned int start, unsigned int 
 				// Respect chunk_len and do not capture checksum as data
 				break;
 			}
-			if(chunk_addr < start) {
+			if((chunk_addr + offset) < start) {
 				free(buf);
 				ERROR2("Address %04x is out of range at line %d\n", chunk_addr, line_no);
 			}
-			if(chunk_addr + chunk_len > end) {
+			if(chunk_addr + offset + chunk_len > end) {
 				free(buf);
 				ERROR2("Address %04x + %d is out of range at line %d\n", chunk_addr, chunk_len, line_no);
 			}
-			if(chunk_addr + chunk_len > greatest_addr) {
-				greatest_addr = chunk_addr + chunk_len;
+			if(chunk_addr + offset + chunk_len > greatest_addr) {
+				greatest_addr = chunk_addr + offset + chunk_len;
 			}
-			buf[chunk_addr - start + (i - 9) / 2] = byte;
+			buf[chunk_addr + offset - start + (i - 9) / 2] = byte;
 		}
 	}
 
@@ -64,15 +83,41 @@ int ihex_read(FILE *pFile, unsigned char *buf, unsigned int start, unsigned int 
 }
 
 void ihex_write(FILE *pFile, unsigned char *buf, unsigned int start, unsigned int end) {
-	unsigned int chunk_len, chunk_start, chunk_type, i, byte, line_no = 0, greatest_addr = 0;
+	unsigned int chunk_len, chunk_start, i;
+	int cur_ela = 0; 
+	// If any address is above the first 64k, cause an initial ELA record to be written
+	if (end > 65535)
+	{
+		cur_ela = -1;
+	}
 	chunk_start = start;
 	while(chunk_start < end)
 	{
+		// Assume the rest of the bytes will be written in this chunk
 		chunk_len = end - chunk_start;
+		// Limit the length to 32 bytes per chunk
 		if (chunk_len > 32)
 		{
 			chunk_len = 32;
 		}
+		// Check if length would go past the end of the current 64k block
+		if (((chunk_start & 0xffff) + chunk_len) > 0xffff)
+		{
+			// If so, reduce the length to go only to the end of the block
+			chunk_len = 0x10000 - (chunk_start & 0xffff);
+		}
+
+		// See if the last ELA record that was written matches the current block
+		if (cur_ela != (chunk_start >> 16))
+		{
+			// If not, write an ELA record
+			unsigned char ela_bytes[2];
+			cur_ela = chunk_start >> 16;
+			ela_bytes[0] = HI(cur_ela);
+			ela_bytes[1] = LO(cur_ela);
+			fprintf(pFile, ":02000004%04X%02X\n",cur_ela,checksum(ela_bytes,2,2,0,4));
+		}
+		// Write the data record
 		fprintf(pFile, ":%02X%04X00",chunk_len,chunk_start);
 		for(i = chunk_start - start; i < (chunk_start + chunk_len - start); i++)
 		{
@@ -80,7 +125,9 @@ void ihex_write(FILE *pFile, unsigned char *buf, unsigned int start, unsigned in
 		}
 		fprintf(pFile, "%02X\n", checksum( &buf[chunk_start - start], chunk_len, chunk_len, chunk_start, 0));
 
+		
 		chunk_start += chunk_len;
 	}
+	// Add the END record
 	fprintf(pFile,":00000001FF\n");
 }


### PR DESCRIPTION
… the

intel hex reader, and use Extended Linear Address records in the intel hex
writer when dealing with addresses greater the 64k

This may help with issue #36 if the reporter was using an intel hex file to do the writing.
