### PR TITLE
verify option bytes with stlinkv2 on stm8s003

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Support table
 | stm8l152?6  |  ok   |  FAIL  |  ?   |  ok    |  ok     |  ?    |
 | stm8l152?8  |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
 | stm8l162?8  |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
-| stm8s003?3  |  ok   |  FAIL  |  ?   |  ok    |  ok     |  ?    |
+| stm8s003?3  |  ok   |  FAIL  |  ?   |  ok    |  ok     |  ok   |
 | stm8s005?6  |  ok   |  ?     |  ok  |  ?     |  ?      |  ?    |
 | stm8s007c8  |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |
 | stm8s103f2  |  ?    |  ?     |  ?   |  ?     |  ?      |  ?    |


### PR DESCRIPTION
This process successfully maps TIM2_CH1 to PC5.
 
[h36sa@boblaptop sdcc-examples-stm8]$ stm8flash -c stlinkv2 -p stm8s003f3 -s opt -r x.bin
Determine OPT area
Reading 64 bytes at 0x4800... OK
Bytes received: 64
[h36sa@boblaptop sdcc-examples-stm8]$ xxd x.bin
00000000: 0000 ff00 ff00 ff00 ff00 ff00 0000 0000  ................
00000010: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000020: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000030: 0000 0000 0000 0000 0000 0000 0000 0000  ................
[h36sa@boblaptop sdcc-examples-stm8]$ hexedit x.bin
[h36sa@boblaptop sdcc-examples-stm8]$ xxd x.bin
00000000: 0000 ff01 fe00 ff00 ff00 ff00 0000 0000  ................
00000010: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000020: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000030: 0000 0000 0000 0000 0000 0000 0000 0000  ................
[h36sa@boblaptop sdcc-examples-stm8]$ stm8flash -c stlinkv2 -p stm8s003f3 -s opt -w x.bin
Determine OPT area
Writing binary file 64 bytes at 0x4800... OK
Bytes written: 64