### PR TITLE
stlinkv2: Increase TRY(..) sleep to 10ms

### DIFF
--- a/try.h
+++ b/try.h
@@ -1,7 +1,7 @@
 #define TRY(times, statement) do { 		\
 	int c = (times);			\
 	while(c > 0) {				\
-		usleep(3000);			\
+		usleep(10000);			\
 		if((statement)) break;		\
 		c--;				\
 	}					\


### PR DESCRIPTION
Ebay-style stlink-v2 and stm8s005k6 doesn't work with current value of 3ms
(but works just fine with original stlink-v2) - read/write actions fail
with "Tries exceeded". It seems the programmer can't process read/write
commands if we ask for status too quickly - increasing the in-loop delay
helps while just increasing the number of retries doesn't help.

The limit we have to wait is somewhere between 6.5ms (doesn't work at all)
to 7ms (works always), with 6.8ms having about 50% success rate; so let's
use 10ms to be on a safe side.

Signed-off-by: Vladimir Koutny <vladimir.koutny@streamunlimited.com>