### PR TITLE
Changes required to get it to compile under macOS (Sierra 10.12.5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ ifeq ($(PLATFORM),Linux)
 else ifeq ($(PLATFORM),Darwin)
 	LIBS = $(shell pkg-config --libs libusb-1.0)
 	LIBUSB_CFLAGS = $(shell pkg-config --cflags libusb-1.0)
-	MacOSSDK=$(shell xcrun --show-sdk-path)
-	BASE_CFLAGS += -I$(MacOSSDK)/usr/include/ -I$(MacOSSDK)/usr/include/sys -I$(MacOSSDK)/usr/include/machine
+	#MacOSSDK=$(shell xcrun --show-sdk-path)
+	#BASE_CFLAGS += -I$(MacOSSDK)/usr/include/ -I$(MacOSSDK)/usr/include/sys -I$(MacOSSDK)/usr/include/machine
 else
 # 	Generic case is Windows
 

--- a/pgm.h
+++ b/pgm.h
@@ -2,7 +2,9 @@
 #define __PGM_H
 
 #ifndef WIN32
- #include <endian.h>
+ #ifndef __APPLE__
+  #include <endian.h>
+ #endif
  #include <libusb.h>
 #else
  #include <libusb-1.0/libusb.h>

--- a/stlink.c
+++ b/stlink.c
@@ -4,7 +4,9 @@
 #include <stdio.h>
 #include <stddef.h>
 
-#include <malloc.h>
+#ifndef __APPLE__
+ #include <malloc.h>
+#endif
 #include <assert.h>
 #include <string.h>
 #include <stdbool.h>
@@ -16,7 +18,9 @@
 #include "utils.h"
 
 #ifndef WIN32
-#include <endian.h>
+ #ifndef __APPLE__
+  #include <endian.h>
+ #endif
 #endif
 
 #define STLK_FLAG_ERR 0x01


### PR DESCRIPTION
- Removed **macOS SDK** include directory dependency in `Makefile`
- Added `#ifndef `to remove inclusion of `endian.h` and `malloc.h` in `stlink.c` and `pgm.h`