### PR TITLE
Fix verify using intel hex format.

### DIFF
--- a/main.c
+++ b/main.c
@@ -371,7 +371,7 @@ int main(int argc, char **argv) {
 		int bytes_to_verify;
 		/* reading bytes to RAM */
 		if(is_ext(filename, ".ihx") || is_ext(filename, ".hex")) {
-			bytes_to_verify = ihex_read(f, buf, start, start + bytes_count);
+			bytes_to_verify = ihex_read(f, buf2, start, start + bytes_count);
 		} else {
 			fseek(f, 0L, SEEK_END);
 			bytes_to_verify = ftell(f);


### PR DESCRIPTION
This is a fix for issue #81. It was verified by the reporter of the issue.  

The problem was that when reading the hex file, it was being read into "buf" instead of "buf2".  the intention was that buf would contain the data read from the chip, and buf2 would be the data from the file.  Instead, we were overwriting the data from the chip with the data from the file, and then comparing that to an uninitialized buffer.