### PR TITLE
Add SREC write and verify

### DIFF
--- a/byte_utils.h
+++ b/byte_utils.h
@@ -4,6 +4,7 @@
 #define MP_LITTLE_ENDIAN 0
 #define MP_BIG_ENDIAN 1
 
+#define EH(x) ((unsigned)((x) & 0xff000000) >> 24)
 #define EX(x) (((x) & 0xff0000) >> 16)
 #define HI(x) (((x) & 0xff00) >> 8)
 #define LO(x) ((x) & 0xff)

--- a/main.c
+++ b/main.c
@@ -336,11 +336,6 @@ int main(int argc, char **argv) {
 		}
 		else if(is_ext(filename, ".s19") || is_ext(filename, ".s8") || is_ext(filename, ".srec"))
 		{
-			printf("Reading from Motorola S-record files are not implemented (yet)\n");
-      printf("Exiting...\n");
-			exit(-1);
-
-			//TODO Remove the above message and exit, and implement reading from S-record.
 			fprintf(stderr, "Reading from Motorola S-record file ");
 			srec_write(f, buf, start, start+bytes_count);
 		}
@@ -372,6 +367,10 @@ int main(int argc, char **argv) {
 		/* reading bytes to RAM */
 		if(is_ext(filename, ".ihx") || is_ext(filename, ".hex")) {
 			bytes_to_verify = ihex_read(f, buf2, start, start + bytes_count);
+		}
+		else if(is_ext(filename, ".s19") || is_ext(filename, ".s8") || is_ext(filename, ".srec"))
+		{
+			bytes_to_verify = srec_read(f, buf2, start, start + bytes_count);
 		} else {
 			fseek(f, 0L, SEEK_END);
 			bytes_to_verify = ftell(f);

--- a/srec.c
+++ b/srec.c
@@ -9,17 +9,42 @@
 #include "error.h"
 #include "byte_utils.h"
 
-char line[256];
+// A SRECORD has one of the following formats
+// SXLLAAAADDDD....DDCC
+// SXLLAAAAAADDDD....DDCC
+// SXLLAAAAAAAADDDD....DDCC
+// Where S is the letter 'S', X is a single digit indicating the record type, LL is the length of the
+// record from the start of the address field through the checksum (i.e. the length of the rest of the
+// record), AAAA[AA[AA]] is the address field and can be 16, 24 or 32 bits depending on the record type,
+// DD is the data for the record (and optional for an S0 record, and not present in some other records),
+// anc CC is the ones complement chechsum of the bytes starting at LL up to the last DD byte.
+// The maximum value for LL is 0xFF, indication a length from the first AA byte through CC byte of 255.
+// The maximum total length in characters would then be 4 (for the SXLL characters) plus 255 * 2 plus a 
+// possible carriage return and line feed.  This would then be 4+510+2, or 516 characters.
+char line[516];
 
-static unsigned char checksum(unsigned char *buf, unsigned int length, int chunk_len, int chunk_addr, int chunk_type) {
-  int sum = chunk_len + (LO(chunk_addr)) + (HI(chunk_addr)) + chunk_type;
+/*
+ * Checksum for SRECORD.  Add all the bytes from the record length field through the data, and take
+ * the ones complement.  This includes the address field, which for SRECORDs can be 2 bytes, 3 bytes or
+ * 4 bytes.  In this case, since the upper bytes of the address will be 0 for records of the smaller sizes,
+ * just add all 4 bytes of the address in all cases.
+ * 
+ * The arguments are:
+ * 
+ *  buf		a pointer to the beginning of the data for the record
+ *  length	the length of the data portion of the record
+ *  chunk_len	the length of the record starting at the address and including the checksum
+ *  chunk_addr	starting address for the data in the record
+ *
+ * Returns an unsigned char with the checksum
+ */
+static unsigned char srec_csum(unsigned char *buf, unsigned int length, int chunk_len, int chunk_addr) {
+  int sum = chunk_len + (LO(chunk_addr)) + (HI(chunk_addr)) + (EX(chunk_addr)) + (EH(chunk_addr));
   unsigned int i;
   for(i = 0; i < length; i++) {
     sum += buf[i];
   }
-
-  int complement = (~sum + 1);
-  return complement & 0xff;
+  return ~sum & 0xff;
 }
 
 
@@ -125,6 +150,51 @@ int srec_read(FILE *pFile, unsigned char *buf, unsigned int start, unsigned int 
 
 
 void srec_write(FILE *pFile, unsigned char *buf, unsigned int start, unsigned int end) {
-  ERROR("srec_write is not implemented!");
-  /* Ducplicate most of the code from ihex.c ihex_write. */
+    int data_rectype = 1;  // Use S1 records if possible
+    unsigned int chunk_len, chunk_start, i, addr_width;
+    unsigned int num_records = 0;
+
+    addr_width = 4;
+    if(end >= 1<<16)
+    {
+	if(end >= 1<<24)
+	{
+	    data_rectype = 3; // addresses greater than 24 bit, use S3 records
+	    addr_width = 8;
+	}
+	else
+	{
+	    data_rectype = 2; // addresses greater than 16 bits, but not greater than 24 bits, use S2 records
+	    addr_width = 6;
+	}
+    }
+    fprintf(pFile, "S0030000FC\n"); // Start with an S0 record
+    chunk_start = start;
+    while(chunk_start < end) {
+       // Assume the rest of the bytes will be written in this chunk
+	chunk_len = end - chunk_start;
+	// Limit the length to 32 bytes per chunk
+	if (chunk_len > 32)
+	{
+		chunk_len = 32;
+	}
+        // Write the data record
+        fprintf(pFile, "S%1X%02X%0*X",data_rectype,chunk_len + addr_width/2 + 1,addr_width,chunk_start);
+        for(i = chunk_start - start; i < (chunk_start + chunk_len - start); i++)
+        {
+                fprintf(pFile, "%02X",buf[i]);
+        }
+        fprintf(pFile, "%02X\n", srec_csum( &buf[chunk_start - start], chunk_len, chunk_len + addr_width/2 + 1, chunk_start));
+	num_records++;
+	chunk_start += chunk_len;
+    }
+    
+    // Add S5 record, for count of data records
+    fprintf(pFile, "S503%04X", num_records & 0xffff);
+    fprintf(pFile, "%02X\n", srec_csum(buf, 0, 3, num_records & 0xffff));
+    // Add End record. S9 terminates S1, S8 terminates S2 and S7 terminates S3 records 
+    fprintf(pFile, "S%1X%02X%0*X",10-data_rectype, addr_width/2 + 1, addr_width, 0);
+    fprintf(pFile, "%02X\n", srec_csum(buf, 0, addr_width/2 + 1, 0));
+	
+
 }


### PR DESCRIPTION
I'm not sure if anyone needs it, but I added an implementation of srec_write, and added the logic to the WRITE and VERIFY code to allow specifying SREC files.  The VERIFY code could have been added when srec_read was implemented.