### PR TITLE
Add support for unlocking STM8S105K4

### DIFF
--- a/stm8.c
+++ b/stm8.c
@@ -644,8 +644,8 @@ const stm8_device_t stm8_devices[] = {
         .flash_start = 0x8000,
         .flash_size = 16*1024,
         .flash_block_size = 128,
-        .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .option_bytes_size = 15,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {


### PR DESCRIPTION
Hi,

I managed to unlock brand new STM8S105K4T6 cheap dev board with this change.
The board has been shipped with LED blinking demo program. It has 8 MHz crystal and a LED connected to PE5.

```
$ ./stm8flash -c stlinkv2 -p stm8s105k4t6 -u
Determine OPT area
Due to its file extension (or lack thereof), "Workaround" is considered as RAW BINARY format!
Unlocked device. Option bytes reset to default state.
Bytes written: 15
```