### PR TITLE
Fix SRec S5 field handling

### DIFF
--- a/srec.c
+++ b/srec.c
@@ -92,7 +92,9 @@ int srec_read(FILE *pFile, unsigned char *buf, unsigned int start, unsigned int 
 	if (chunk_len != 3) { // Length field must contain a 3 to be a valid S5 record.
 	  ERROR2("Error while parsing S5 Record at line %d\n", line_no);
 	}
-	expected_data_records = chunk_addr; //The expected total number of data records is saved in S503<addr> field.
+	//The expected total number of data records is saved in S503<addr> field.
+	//Address is only 2 byte long and checksum is also read as part of the address, so we need to strip it.
+	expected_data_records = chunk_addr >> 8;
       }
     else if(is_data_type(chunk_type))
       {


### PR DESCRIPTION
S5 records has 2-byte long address field that contain number of data
records expected in the file, but address is read as a 4-byte long hex
value, which results in checksum becoming part of the address read.
This gives incorrect number of data records and as a result the tools
rejects any file with S5 records.