### PR TITLE
Fix reset functionality for espstlink

### DIFF
--- a/espstlink.c
+++ b/espstlink.c
@@ -44,14 +44,15 @@ static bool espstlink_write_byte(programmer_t *pgm, uint8_t byte,
 }
 
 static bool espstlink_swim_reconnect(programmer_t *pgm) {
-  // Pull reset low, if the programmer firmware supports this.
   int version = pgm->espstlink->version;
-  if (version > 0 && !espstlink_reset(pgm->espstlink, 0, 0)) return 0;
+
+  // Enter reset state, if the programmer firmware supports this.
+  if (version > 0 && !espstlink_reset(pgm->espstlink, /*input=*/0, 1)) return 0;
 
   if (!espstlink_swim_entry(pgm->espstlink)) return 0;
 
   // Put the reset pin back into pullup state.
-  if (version > 0 && !espstlink_reset(pgm->espstlink, 1, 0)) return 0;
+  if (version > 0 && !espstlink_reset(pgm->espstlink, /*input=*/1, 0)) return 0;
 
   if (!espstlink_swim_srst(pgm->espstlink)) return 0;
   usleep(1);

--- a/espstlink.c
+++ b/espstlink.c
@@ -98,8 +98,6 @@ static void espstlink_wait_until_transfer_completes(
 int espstlink_swim_read_range(programmer_t *pgm, const stm8_device_t *device,
                               unsigned char *buffer, unsigned int start,
                               unsigned int length) {
-  espstlink_swim_reconnect(pgm);
-
   size_t i = 0;
   for (; i < length;) {
     int current_size = MIN(length - i, 255);
@@ -114,7 +112,6 @@ int espstlink_swim_read_range(programmer_t *pgm, const stm8_device_t *device,
 int espstlink_swim_write_range(programmer_t *pgm, const stm8_device_t *device,
                                unsigned char *buffer, unsigned int start,
                                unsigned int length, const memtype_t memtype) {
-  espstlink_swim_reconnect(pgm);
   espstlink_prepare_for_flash(pgm, device, memtype);
 
   size_t i = 0;

--- a/libespstlink.c
+++ b/libespstlink.c
@@ -95,6 +95,44 @@ espstlink_t *espstlink_open(const char *device) {
   return pgm;
 }
 
+static const char *command_name(uint8_t command) {
+  switch (command) {
+    case 0:
+      return "SOFT_RESET";
+    case 1:
+      return "READ";
+    case 2:
+      return "WRITE";
+    case 0xFD:
+      return "HARD_RESET";
+    case 0xFE:
+      return "SWIM_ENTRY";
+    case 0xFF:
+      return "GET_VERSION";
+    default:
+      return "unknown (invalid)";
+  }
+}
+
+static const char *swim_error_name(int code) {
+  switch (-code) {
+    case ESPSTLINK_SWIM_ERROR_READ_BIT_TIMEOUT:
+      return "READ_BIT_TIMEOUT";
+    case ESPSTLINK_SWIM_ERROR_INVALID_TARGET_ID:
+      return "INVALID_TARGET_ID";
+    case ESPSTLINK_SWIM_ERROR_PARITY:
+      return "PARITY";
+    case ESPSTLINK_SWIM_ERROR_NACK:
+      return "NACK";
+    case ESPSTLINK_SWIM_ERROR_SYNC_TIMEOUT_1:
+      return "SYNC_TIMEOUT_1";
+    case ESPSTLINK_SWIM_ERROR_SYNC_TIMEOUT_2:
+      return "SYNC_TIMEOUT_2";
+    default:
+      return "unknown (invalid)";
+  }
+}
+
 static bool error_check(int fd, uint8_t command, uint8_t *resp_buf,
                         size_t size) {
   uint8_t buf[4];
@@ -112,8 +150,9 @@ static bool error_check(int fd, uint8_t command, uint8_t *resp_buf,
   }
   len = read(fd, buf + 1, 1);
   if (len < 1) {
-    set_error(ESPSTLINK_ERROR_DATA, "Device didn't finish command 0x%02x: %s\n",
-              buf[0], strerror(errno));
+    set_error(ESPSTLINK_ERROR_DATA,
+              "Device didn't finish command 0x%02x (%s): %s\n", buf[0],
+              command_name(buf[0]), strerror(errno));
     return 0;
   }
   if (buf[1] == 0) {
@@ -124,9 +163,9 @@ static bool error_check(int fd, uint8_t command, uint8_t *resp_buf,
         if (len < 1) {
           set_error(
               ESPSTLINK_ERROR_DATA,
-              "Incomplete response for command 0x%02x: expected %d bytes, "
+              "Incomplete response for command 0x%02x (%s): expected %d bytes, "
               "but got %d bytes (%s)\n",
-              buf[0], size, len, strerror(errno));
+              buf[0], command_name(buf[0]), size, len, strerror(errno));
           return 0;
         }
         total += len;
@@ -137,20 +176,21 @@ static bool error_check(int fd, uint8_t command, uint8_t *resp_buf,
   if (buf[1] == 0xFF) {
     len = read(fd, buf + 2, 2);
     if (len < 2) {
-      set_error(
-          ESPSTLINK_ERROR_DATA,
-          "Device didn't finish sending error code for command 0x%02x: %s\n",
-          buf[0], strerror(errno));
+      set_error(ESPSTLINK_ERROR_DATA,
+                "Device didn't finish sending error code for command 0x%02x "
+                "(%s): %s\n",
+                buf[0], command_name(buf[0]), strerror(errno));
       return 0;
     }
     int code = buf[2] << 8 | buf[3];
-    set_error(ESPSTLINK_ERROR_COMM, "Command 0x%02x failed with code: 0x%02x\n",
-              buf[0], code);
+    set_error(ESPSTLINK_ERROR_COMM,
+              "Command 0x%02x (%s) failed with code: 0x%02x (%s)\n", buf[0],
+              command_name(buf[0]), code, swim_error_name(code));
     error.device_code = code;
   } else {
     set_error(ESPSTLINK_ERROR_DATA,
-              "Unexpected error code for command 0x%02x: 0x%02x\n", buf[0],
-              buf[1]);
+              "Unexpected error code for command 0x%02x (%s): 0x%02x\n", buf[0],
+              command_name(buf[0]), buf[1]);
     error.data[0] = buf[0];
     error.data[1] = buf[1];
     error.data_len = 2 + read(fd, &error.data[2], sizeof(error.data) - 2);

--- a/libespstlink.c
+++ b/libespstlink.c
@@ -192,8 +192,8 @@ bool espstlink_swim_entry(const espstlink_t *pgm) {
   return 1;
 }
 
-bool espstlink_reset(const espstlink_t *pgm, bool input, bool value) {
-  uint8_t cmd[] = {0xFD, input ? 0xFF : value};
+bool espstlink_reset(const espstlink_t *pgm, bool input, bool enable_reset) {
+  uint8_t cmd[] = {0xFD, input ? 0xFF : enable_reset};
 
   write(pgm->fd, cmd, 2);
   return error_check(pgm->fd, cmd[0], NULL, 0);

--- a/libespstlink.h
+++ b/libespstlink.h
@@ -43,8 +43,9 @@ bool espstlink_swim_write(const espstlink_t *pgm, const uint8_t *buffer,
 /**
  * Switch the reset pin.
  * If `input`, the pin is used as an input pin with a pull-up resistor.
- * Otherwise, the pin is used as an output pin, pulled low or high depending on
- * `value`.
+ * Otherwise, the pin is used as an output pin as follows:
+ * value == 0: DEFAULT, sets the pin HIGH
+ * value == 1: RESET, sets the pin LOW
  */
-bool espstlink_reset(const espstlink_t *pgm, bool input, bool value);
+bool espstlink_reset(const espstlink_t *pgm, bool input, bool enable_reset);
 #endif

--- a/libespstlink.h
+++ b/libespstlink.h
@@ -27,6 +27,13 @@ typedef struct _esplink_error_t {
 #define ESPSTLINK_ERROR_COMM 3
 #define ESPSTLINK_ERROR_VERSION 4
 
+#define ESPSTLINK_SWIM_ERROR_READ_BIT_TIMEOUT -1
+#define ESPSTLINK_SWIM_ERROR_INVALID_TARGET_ID -2
+#define ESPSTLINK_SWIM_ERROR_PARITY -3
+#define ESPSTLINK_SWIM_ERROR_NACK -4
+#define ESPSTLINK_SWIM_ERROR_SYNC_TIMEOUT_1 -5
+#define ESPSTLINK_SWIM_ERROR_SYNC_TIMEOUT_2 -6
+
 espstlink_error_t *espstlink_get_last_error();
 
 espstlink_t *espstlink_open(const char *device);

--- a/stlinkv2.c
+++ b/stlinkv2.c
@@ -122,7 +122,11 @@ void stlink2_init_session(programmer_t *pgm) {
 	stlink2_cmd(pgm, 0xf408, 0);
 	TRY(8, stlink2_get_status(pgm) == 0);
 
+	// This is probably a bug: Should set the STALL bit (write 8 instead of
+	// A0) What is currently being done: DM_CSR2 (0x7f99): Reserved (0x80) |
+	// Software breakpoint control (0x20)
 	stlink2_write_and_read_byte(pgm, 0xa0, 0x7f99);
+
 	stlink2_cmd(pgm, 0xf40c, 0);
 	msg_recv_int8(pgm); // 0x08 (or 0x0a if used stlink2_write_byte() instead)
 }


### PR DESCRIPTION
Also includes other fixes (e.g. improve error messages and unstall the CPU after flashing so that the programm execution starts immediately).