### PR TITLE
STM8S207 option byte support

### DIFF
--- a/stm8.c
+++ b/stm8.c
@@ -696,8 +696,8 @@ const stm8_device_t stm8_devices[] = {
         .flash_start = 0x8000,
         .flash_size = 64*1024,
         .flash_block_size = 128,
-        .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .option_bytes_size = 17,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {

--- a/stm8.c
+++ b/stm8.c
@@ -683,8 +683,8 @@ const stm8_device_t stm8_devices[] = {
         .flash_start = 0x8000,
         .flash_size = 128*1024,
         .flash_block_size = 128,
-        .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .option_bytes_size = 17,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -748,8 +748,8 @@ const stm8_device_t stm8_devices[] = {
         .flash_start = 0x8000,
         .flash_size = 128*1024,
         .flash_block_size = 128,
-        .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .option_bytes_size = 17,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -910,4 +910,3 @@ const stm8_device_t stm8_devices[] = {
     },
     { NULL },
 };
-


### PR DESCRIPTION
The branch has implemented option byte support for STM8S207. It would be good to have the feature upstream, assuming it has been tested (testing results should be indicated in README.md).