### PR TITLE
Fix Intel Hex output when reading flash >32KB size

### DIFF
--- a/ihex.c
+++ b/ihex.c
@@ -132,7 +132,7 @@ void ihex_write(FILE *pFile, unsigned char *buf, unsigned int start, unsigned in
 			fprintf(pFile, ":02000004%04X%02X\n",cur_ela,checksum(ela_bytes,2,2,0,4));
 		}
 		// Write the data record
-		fprintf(pFile, ":%02X%04X00",chunk_len,chunk_start);
+		fprintf(pFile, ":%02X%04X00",chunk_len,chunk_start & 0xffff);
 		for(i = chunk_start - start; i < (chunk_start + chunk_len - start); i++)
 		{
 			fprintf(pFile, "%02X",buf[i]);


### PR DESCRIPTION
This fixes the bug reported in issue #126.

Compiled and tested on Linux with a Nucleo-64 board featuring a STM8S208RB (128KB flash).

```
$ sudo ./stm8flash -c stlinkv21 -p stm8s208rb -s flash -r test.srec
Determine FLASH area
Due to its file extension (or lack thereof), "test.srec" is considered as MOTOROLA S-RECORD format!
Reading 131072 bytes at 0x8000... OK
Bytes received: 131072
$ sudo ./stm8flash -c stlinkv21 -p stm8s208rb -s flash -r test-after.hex
Determine FLASH area
Due to its file extension (or lack thereof), "test-after.hex" is considered as INTEL HEX format!
Reading 131072 bytes at 0x8000... OK
Bytes received: 131072
$ srec_cat -output test.srec.bin -binary test.srec
$ srec_cat -output test-after.hex.bin -binary test-after.hex -intel
$ diff -s test.srec.bin test-after.hex.bin 
Files test.srec.bin and test-after.hex.bin are identical
$ md5sum test.srec.bin test-after.hex.bin
87e407327bbefb39d357327a4a3d43ad  test.srec.bin
87e407327bbefb39d357327a4a3d43ad  test-after.hex.bin
```