### PR TITLE
rewrite of stlinkv2 driver - take 2

### DIFF
--- a/LICENSE-CHANGE
+++ b/LICENSE-CHANGE
@@ -17,6 +17,7 @@ Jan Szumiec <jan.szumiec@gmail.com>
 Tim <cpldcpu@gmail.com>
 Bill Lash <william.lash@gmail.com>
 Erno Szabados <erno.szabados@windowslive.com>
+Stefaan De Smet <stefaandesmet2003@yahoo.co.uk>
 
 Authors that have not agreed:
 

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,13 @@
 
 
 PLATFORM=$(shell uname -s)
+DEBUG=0
 
 # Pass RELEASE=anything to build without debug symbols
 ifneq (,$(strip $(RELEASE)))
 	BASE_CFLAGS := -O1
 else
-	BASE_CFLAGS := -g -O0
+	BASE_CFLAGS := -g -O0 -DDEBUG=$(DEBUG)
 endif
 
 # Pass LIBUSB_QUIET=anything to Make to silence debug output from libusb.

--- a/stlinkv2.c
+++ b/stlinkv2.c
@@ -384,13 +384,13 @@ bool stlink2_open(programmer_t *pgm) {
 }
 
 void stlink2_srst(programmer_t *pgm) {
+	swim_write_byte(pgm, swim_read_byte(pgm, 0x7f80) | 0x4, 0x7f80); // set SWIM_CSR.RST
+	// alt : remove stall bit after reset (like libespstlink)
 	swim_cmd(pgm, 2, STLINK_SWIM, SWIM_GEN_RST);
 	usleep(1000);
 }
 
-void stlink2_finish_session(programmer_t *pgm) {
-	swim_write_byte(pgm, swim_read_byte(pgm, 0x7f80) | 0x4, 0x7f80); // set SWIM_CSR.RST
-	swim_cmd(pgm, 2, STLINK_SWIM, SWIM_GEN_RST);
+void stlink2_close(programmer_t *pgm) {
 	stlink2_cmd(pgm, 2, STLINK_SWIM, SWIM_EXIT);
 }
 
@@ -444,7 +444,6 @@ int stlink2_swim_read_range(programmer_t *pgm, const stm8_device_t *device, unsi
 		remaining -= size;
 	}
 
-	stlink2_finish_session(pgm);
 	return length;
 }
 
@@ -539,6 +538,5 @@ int stlink2_swim_write_range(programmer_t *pgm, const stm8_device_t *device, uns
 		swim_write_byte(pgm, iapsr & (~0x0a), device->regs.FLASH_IAPSR);
 	}
 
-	stlink2_finish_session(pgm);
 	return(length);
 }

--- a/stlinkv2.c
+++ b/stlinkv2.c
@@ -476,9 +476,7 @@ int stlink2_swim_write_range(programmer_t *pgm, const stm8_device_t *device, uns
 
 		// Wait for EOP to be set in FLASH_IAPSR
 		usleep(6000); // t_prog per the datasheets is 6ms typ, 6.6ms max
-		while (!((iapsr = swim_read_byte(pgm, device->regs.FLASH_IAPSR)) & 0x04)) {
-			usleep(100);
-		}
+		TRY(5,swim_read_byte(pgm, device->regs.FLASH_IAPSR) & 0x04);
 	} else {
 		unsigned int rounded_size = ((length - 1) / device->flash_block_size + 1) * device->flash_block_size;
 		unsigned char *current = alloca(rounded_size);
@@ -525,9 +523,7 @@ int stlink2_swim_write_range(programmer_t *pgm, const stm8_device_t *device, uns
 					// Wait for EOP to be set in FLASH_IAPSR
 					// t_prog per the datasheets is 6ms typ, 6.6ms max, fast mode is twice as fast
 					usleep(prgmode == 0x10 ? 3000 : 6000);
-					while (!((iapsr = swim_read_byte(pgm, device->regs.FLASH_IAPSR)) & 0x04)) {
-						usleep(100);
-					}
+					TRY(5,swim_read_byte(pgm, device->regs.FLASH_IAPSR) & 0x04);
 				}
 			}
 		}
@@ -535,6 +531,7 @@ int stlink2_swim_write_range(programmer_t *pgm, const stm8_device_t *device, uns
 
 	if (memtype == FLASH || memtype == EEPROM || memtype == OPT) {
 		// Reset DUL and PUL in IAPSR to disable flash and data writes.
+		iapsr = swim_read_byte(pgm, device->regs.FLASH_IAPSR);
 		swim_write_byte(pgm, iapsr & (~0x0a), device->regs.FLASH_IAPSR);
 	}
 

--- a/utils.h
+++ b/utils.h
@@ -1,8 +1,8 @@
 #ifndef __UTILS_H
 #define __UTILS_H
 
-#ifdef DEBUG
-#define DEBUG_PRINT(...) do{ fprintf( stderr, __VA_ARGS__ ); } while( false )
+#if DEBUG
+#define DEBUG_PRINT(...) do{ fprintf( stderr, __VA_ARGS__ ); fflush(stderr); } while( false )
 #else
 #define DEBUG_PRINT(...) do{ } while ( false )
 #endif


### PR DESCRIPTION
Hi,
for you to consider this PR. It's the original work from @mjagdis (PR #108) , updated for automatic merge in current repository.

Modifications in this PR :
- adds SWIM high-speed mode, resulting in faster read & write times
- on write, only rewrites changes to flash. improves flash longevity and programming times
- uses fast block programming (avoid unnecessary erase) if flash block is already erased (all zeroes)
- replaced the fixed number of retries with a dynamic mechanism based on the read status from the stlinkv2. And removes a number of undocumented delays. This will improve the read/write times and timeout behaviour in general.
- adds a debugging mode (make DEBUG=1). This can help identify the cause of issues opened on this repo. (basically you can ask the issue author to post a log of the debug info to have a better understanding of his issue)

For info, the flash write time is at least 4x faster (1s vs 4s for a 8k flash) than the current base repo version.

Because of the substantial changes, it might be useful to perform some tests on different STM8S & STM8L to confirm this change doesn't break any support.
But i hope you will find the changes interesting enough to consider.
Cheers,
Stefaan