### PR TITLE
stm8l152?4 flash_block_size update

### DIFF
--- a/stm8.c
+++ b/stm8.c
@@ -513,7 +513,7 @@ const stm8_device_t stm8_devices[] = {
         .eeprom_size = 1024,
         .flash_start = 0x8000,
         .flash_size = 16*1024,
-        .flash_block_size = 64,
+        .flash_block_size = 128,
         .option_bytes_size = 13,
         .read_out_protection_mode = ROP_STM8L,
         REGS_STM8L


### PR DESCRIPTION
Set stm8l152?4 flash_block_size to 128 (64 was not working).
Tested on STM8L152K4 board successfully.