### PR TITLE
autodetect first working version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ ifndef DESTDIR
 endif
 
 BIN 		=stm8flash
-OBJECTS 	=stlink.o stlinkv2.o espstlink.o main.o byte_utils.o ihex.o srec.o stm8.o libespstlink.o
+OBJECTS 	=stlink.o stlinkv2.o espstlink.o main.o byte_utils.o ihex.o srec.o stm8.o libespstlink.o autodetect.o
 
 
 .PHONY: all clean install

--- a/autodetect.c
+++ b/autodetect.c
@@ -1,0 +1,537 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <string.h>
+#include <unistd.h>
+#include "autodetect.h"
+#include "byte_utils.h"
+#include "utils.h"
+  
+#define SWIM_PCE      0x7F01
+#define SWIM_PCH      0x7F02
+#define SWIM_PCL      0x7F03
+#define SWIM_SPH      0x7F08
+#define SWIM_SPL      0x7F09
+#define SWIM_CSR      0x7F80
+#define DM_CSR2       0x7F99
+
+#define ID_ADDRESS1   0x4FFC
+#define ID_ADDRESS2   0x67F0
+#define ID_ADDRESS3   0x67F1
+
+#define FLASH_START   0x8000
+#define BOOTROM_START 0x6000
+#define RAM_START     0x0000
+
+typedef enum {
+  REGSET_STM8S,
+  REGSET_STM8L
+} regset_t;
+
+static const stm8_regs_t stm8_regs[] = {REGS_STM8S, REGS_STM8L};
+
+static unsigned char buffer[10];
+
+typedef struct {
+  uint16_t type_id_address;
+  uint32_t type_id_value;
+  const char *type_name;
+  uint32_t ram_size;
+  uint32_t flash_min_size;
+  uint32_t flash_max_size;
+  uint32_t flash_block_size;
+  uint32_t eeprom_base_address;
+  uint32_t eeprom_min_size;
+  uint32_t eeprom_max_size;
+  uint16_t unique_id_address;
+  uint16_t unique_id_address_len;
+  bool has_bootrom;
+  ROP_type_t read_out_protection_mode;
+  regset_t regset;
+
+} stm8_autodetect_type_t;
+
+static const stm8_autodetect_type_t stm8_autodetect_types[] = {
+  {
+    .type_id_address = 0x67F0,
+    .type_id_value = 0x37394241,
+    .type_name = "STM8AF/STM8S005",
+    .ram_size = 2*1024,
+    .flash_min_size = 16*1024,
+    .flash_max_size = 32*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x4000,
+    .eeprom_min_size = 640,
+    .eeprom_max_size = 1024,
+    .unique_id_address = 0x48CD, // this type has no uniqueID, but will check this address to distinguish from STM8S105
+    .unique_id_address_len = 0,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {
+    .type_id_address = 0x67F0,
+    .type_id_value = 0x37394241,
+    .type_name = "STM8S105",
+    .ram_size = 2*1024,
+    .flash_min_size = 16*1024,
+    .flash_max_size = 32*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x4000,
+    .eeprom_min_size = 1024,
+    .eeprom_max_size = 1024,
+    .unique_id_address = 0x48CD,
+    .unique_id_address_len = 12,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {  // anyone a datasheet for this type?
+    .type_id_address = 0x67F0,
+    .type_id_value = 0x37394341,
+    .type_name = "STM8AF51/STM8AH51",
+    .ram_size = 6*1024,
+    .flash_min_size = 128*1024,
+    .flash_max_size = 128*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x4000, 
+    .eeprom_min_size = 0,
+    .eeprom_max_size = 0xFFFF,
+    .unique_id_address = 0,
+    .unique_id_address_len = 0,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {  // anyone a datasheet for this type?
+    .type_id_address = 0x67F0,
+    .type_id_value = 0x37394341,
+    .type_name = "STM8AF51/STM8AH51",
+    .ram_size = 12*1024,
+    .flash_min_size = 256*1024,
+    .flash_max_size = 256*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x4000, 
+    .eeprom_min_size = 0,
+    .eeprom_max_size = 0xFFFF,
+    .unique_id_address = 0,
+    .unique_id_address_len = 0,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {
+    .type_id_address = 0x67F0,
+    .type_id_value = 0x79314141,
+    .type_name = "STLUX",
+    .ram_size = 2*1024,
+    .flash_min_size = 32*1024,
+    .flash_max_size = 32*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x4000, 
+    .eeprom_min_size = 1024,
+    .eeprom_max_size = 1024,
+    .unique_id_address = 48E0,
+    .unique_id_address_len = 8,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {
+    .type_id_address = 0x67F0,
+    .type_id_value = 0x79314141,
+    .type_name = "STNRG",
+    .ram_size = 6*1024,
+    .flash_min_size = 32*1024,
+    .flash_max_size = 32*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x4000, 
+    .eeprom_min_size = 1024,
+    .eeprom_max_size = 1024,
+    .unique_id_address = 48E0,
+    .unique_id_address_len = 8,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  { // anyone a datasheet for this type?
+    .type_id_address = 0x67F1,
+    .type_id_value = 0x55576588,
+    .type_name = "STMAF51/STMAH51 32k",
+    .ram_size = 2*1024,
+    .flash_min_size = 32*1024,
+    .flash_max_size = 32*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x4000, 
+    .eeprom_min_size = 0,
+    .eeprom_max_size = 0xFFFF,
+    .unique_id_address = 0,
+    .unique_id_address_len = 0,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  { // anyone a datasheet for this type?
+    .type_id_address = 0x67F1,
+    .type_id_value = 0x55576588,
+    .type_name = "STMAF51/STMAH51 48k",
+    .ram_size = 3*1024,
+    .flash_min_size = 48*1024,
+    .flash_max_size = 48*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x4000, 
+    .eeprom_min_size = 0,
+    .eeprom_max_size = 0xFFFF,
+    .unique_id_address = 0,
+    .unique_id_address_len = 0,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  { // anyone a datasheet for this type?
+    .type_id_address = 0x67F1,
+    .type_id_value = 0x55576588,
+    .type_name = "STMAF51/STMAH51 64k",
+    .ram_size = 4*1024,
+    .flash_min_size = 64*1024,
+    .flash_max_size = 64*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x4000, 
+    .eeprom_min_size = 0,
+    .eeprom_max_size = 0xFFFF,
+    .unique_id_address = 0,
+    .unique_id_address_len = 0,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  { // anyone a datasheet for this type?
+    .type_id_address = 0x67F1,
+    .type_id_value = 0x55576588,
+    .type_name = "STMAF52/STMAF62",
+    .ram_size = 6*1024,
+    .flash_min_size = 64*1024,
+    .flash_max_size = 128*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x4000, 
+    .eeprom_min_size = 1024,
+    .eeprom_max_size = 2048,
+    .unique_id_address = 0x48CD, // this type has no uniqueID, but will check this address to distinguish from STM8S208
+    .unique_id_address_len = 0,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {
+    .type_id_address = 0x67F1,
+    .type_id_value = 0x55576588,
+    .type_name = "STM8S208",
+    .ram_size = 6*1024,
+    .flash_min_size = 64*1024,
+    .flash_max_size = 128*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x4000,
+    .eeprom_min_size = 1024,
+    .eeprom_max_size = 2048,
+    .unique_id_address = 0x48CD,
+    .unique_id_address_len = 12,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {
+    .type_id_address = 0x4FFC,
+    .type_id_value = 0x67581000,
+    .type_name = "STM8Lx5",
+    .ram_size = 1*1024,
+    .flash_min_size = 8*1024,
+    .flash_max_size = 8*1024,
+    .flash_block_size = 64,
+    .eeprom_base_address = 0x1000,
+    .eeprom_min_size = 256,
+    .eeprom_max_size = 256,
+    .unique_id_address = 0,
+    .unique_id_address_len = 0,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {
+    .type_id_address = 0x4FFC,
+    .type_id_value = 0x67611000,
+    .type_name = "STM8Lx01/STM8AL30xx",
+    .ram_size = 1*1024 + 512, // 1.5k
+    .flash_min_size = 4*1024,
+    .flash_max_size = 8*1024,
+    .flash_block_size = 64,
+    .eeprom_base_address = 0x0, // part of flash
+    .eeprom_min_size = 0,
+    .eeprom_max_size = 0,
+    .unique_id_address = 0x4925,
+    .unique_id_address_len = 6,
+    .has_bootrom = false,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {
+    .type_id_address = 0x4FFC,
+    .type_id_value = 0x67641000,
+    .type_name = "STM8AL31/STM8AL3L/STM8L151",
+    .ram_size = 2*1024,
+    .flash_min_size = 8*1024,
+    .flash_max_size = 64*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x1000,
+    .eeprom_min_size = 1024,
+    .eeprom_max_size = 2048,
+    .unique_id_address = 0x4926,
+    .unique_id_address_len = 6,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {
+    .type_id_address = 0x4FFC,
+    .type_id_value = 0x67671000,
+    .type_name = "STM8Sx03",
+    .ram_size = 1*1024,
+    .flash_min_size = 4*1024,
+    .flash_max_size = 8*1024,
+    .flash_block_size = 64,
+    .eeprom_base_address = 0x4000,
+    .eeprom_min_size = 640,
+    .eeprom_max_size = 640,
+    .unique_id_address = 0x4865,
+    .unique_id_address_len = 12,
+    .has_bootrom = false,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {
+    .type_id_address = 0x4FFC,
+    .type_id_value = 0x67681000,
+    .type_name = "STM8L15x",
+    .ram_size = 2*1024,
+    .flash_min_size = 32*1024,
+    .flash_max_size = 64*1024,
+    .flash_block_size = 128,
+    .eeprom_base_address = 0x1000,
+    .eeprom_min_size = 1024,
+    .eeprom_max_size = 1024,
+    .unique_id_address = 0x4926,
+    .unique_id_address_len = 6,
+    .has_bootrom = true,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {
+    .type_id_address = 0x4FFC,
+    .type_id_value = 0x67691000,
+    .type_name = "STM8TL5",
+    .ram_size = 4*1024,
+    .flash_min_size = 16*1024,
+    .flash_max_size = 16*1024,
+    .flash_block_size = 64,
+    .eeprom_base_address = 0, //part of flash
+    .eeprom_min_size = 0,
+    .eeprom_max_size = 0,
+    .unique_id_address = 0x4925,
+    .unique_id_address_len = 6,
+    .has_bootrom = false,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+  {
+    .type_id_address = 0x4FFC,
+    .type_id_value = 0x67991000,
+    .type_name = "STM8AF62",
+    .ram_size = 1*1024,
+    .flash_min_size = 4*1024,
+    .flash_max_size = 8*1024,
+    .flash_block_size = 64,
+    .eeprom_base_address = 0x4000,
+    .eeprom_min_size = 640,
+    .eeprom_max_size = 640,
+    .unique_id_address = 0x4865,
+    .unique_id_address_len = 12,
+    .has_bootrom = false,
+    .read_out_protection_mode = ROP_STM8S,
+    .regset = REGSET_STM8S
+  },
+};
+
+// find a match from the table above, starting from index
+// returns number of matches, and updates index with first match
+static uint8_t find_type (uint16_t id_address, uint32_t id_value, uint32_t id_mask, uint32_t ram_size, 
+                      uint8_t *index) 
+{
+  uint8_t num_types = sizeof(stm8_autodetect_types)/sizeof(stm8_autodetect_type_t);
+  uint8_t num_matches = 0;
+  uint8_t start_index = *index;
+
+  for (uint8_t i=start_index;i<num_types;i++) {
+    if ((id_address == stm8_autodetect_types[i].type_id_address) &&
+        ((id_value & id_mask) == (stm8_autodetect_types[i].type_id_value & id_mask)) &&
+        (ram_size == stm8_autodetect_types[i].ram_size))
+        {
+          if (!num_matches)
+            *index = i; // pass the first match
+          num_matches++;
+        }
+  }
+  return num_matches;
+}
+
+int autodetect(programmer_t *pgm, stm8_device_t *autodetect_device)
+{
+  uint32_t ram_size;
+  const stm8_autodetect_type_t *stm8_type;
+  uint32_t u32; // a 4-byte value
+  bool has_bootrom = false;
+
+  DEBUG_PRINT("starting autodetection\n");
+
+  // assume we can perform read_range with device==NULL
+  // purpose is to detect the device type, and derive the part specific registers
+  // is ok for current stlink/espstlink drivers
+
+  // first check for read-out protection
+  pgm->read_range(pgm,NULL,buffer, FLASH_START, 4);
+  u32 = load_int(buffer, 4, MP_BIG_ENDIAN);
+  DEBUG_PRINT("reading 0x%x at flast start address : ",u32);
+  if (u32 == 0x71717171) {
+    fprintf(stderr, "active read-out protection prevents device auto-detection\n");
+    return -1;
+  }
+  else {
+    DEBUG_PRINT("no read-out protection active. proceeding with autodetection\n");
+  }
+
+  autodetect_device->name = NULL;
+
+  // this assumes that the driver has stalled the CPU on ->open()
+  // otherwise the PC/SPL could have moved while SWIM was activated
+
+  // determine ram size -> read SPH/SPL (stack pointer)
+  pgm->read_range(pgm,NULL,buffer, SWIM_SPH, 2);
+  ram_size = load_int(buffer, 2, MP_BIG_ENDIAN);
+  ram_size += 1;
+  fprintf(stderr, "found SP = 0x%x, assuming ram size = %dK\n",(ram_size-1), ram_size/1024);
+
+  // reading a few bytes at bootrom address BOOTROM_START = 0x6000
+  pgm->read_range(pgm,NULL,buffer, BOOTROM_START, 4);
+  u32 = load_int(buffer, 4, MP_BIG_ENDIAN);
+  DEBUG_PRINT("reading 0x%x at bootrom start address : ",u32);
+  if (u32 == 0x71717171) {
+    has_bootrom = false;
+    fprintf(stderr,"bootrom not present\n");
+  }
+  else {
+    has_bootrom = true;
+    fprintf(stderr,"bootrom is present\n");
+  }
+
+  // reading PC
+  pgm->read_range(pgm,NULL,buffer, SWIM_PCE, 3);
+  u32 = load_int(buffer, 3, MP_BIG_ENDIAN);
+  fprintf(stderr, "found PC = 0x%x : ",u32);
+  if (u32 >= FLASH_START) {
+    if (has_bootrom)
+      fprintf(stderr,"bootrom not active, ");
+    fprintf(stderr,"mcu currently stalled in flash\n");
+  }
+  else if (u32 >= BOOTROM_START)
+    fprintf(stderr,"mcu currently stalled in bootrom\n");
+
+  uint16_t id_addresses[] = {ID_ADDRESS1, ID_ADDRESS2, ID_ADDRESS3};
+  uint32_t id_masks[] = {0xFFFF0000, 0xFF00, 0xFFFF};
+  for (uint8_t i=0; i<3;i++) { // loop the 3 possible ID address locations
+    uint16_t id_address;
+    uint32_t id_value, id_mask;
+    uint8_t num_matches, find_index;
+    bool match_ok;
+
+    id_address = id_addresses[i];
+    id_mask = id_masks[i];
+
+    // reading id address
+    pgm->read_range(pgm,NULL,buffer, id_address, 4);
+    id_value = load_int(buffer, 4, MP_BIG_ENDIAN);
+    DEBUG_PRINT("id @ %x = 0x%x\n",id_address, id_value);
+
+    // check for matches in the lookup table
+    find_index = 0;
+    if (id_value != 0 && id_value != 0x71717171) {
+      do {
+        num_matches = find_type(id_address, id_value, id_mask, ram_size, &find_index);
+        if (!num_matches)
+          continue; // no matches found on id_address
+
+        match_ok = true;
+        stm8_type = &stm8_autodetect_types[find_index];
+        find_index++; // prepare for next round
+        DEBUG_PRINT("%d potential matches left\n", num_matches);
+        DEBUG_PRINT("checking type %s\n",stm8_type->type_name);
+        // check if match is plausible
+        if (has_bootrom != stm8_type->has_bootrom) {
+          match_ok = false;
+          DEBUG_PRINT("-> no matching bootrom\n");
+        }
+        if (stm8_type->unique_id_address != 0) {
+          // read a unique ID
+          uint32_t uid;
+          pgm->read_range(pgm,NULL,buffer, stm8_type->unique_id_address, 4);
+          uid = load_int(buffer, 4, MP_BIG_ENDIAN);
+          DEBUG_PRINT("uniqueID initial 4 bytes = 0x%x\n",uid);
+          if ((stm8_type->unique_id_address_len) && ((uid == 0 || uid == 0x71717171))) {
+            match_ok = false;
+            DEBUG_PRINT("-> no valid unique ID\n");
+          }
+          if ((!stm8_type->unique_id_address_len) && (uid != 0) && (uid != 0x71717171)) {
+            match_ok = false;
+            DEBUG_PRINT("-> found unexpected unique ID\n");
+          }
+        }
+        if (match_ok) {
+          fprintf(stderr,"possible match! found %s with %d bytes RAM, flash size between %d and %d, "
+            "eeprom at 0x%x with size between %d and %d, "
+            "flash block size = %d\n",
+            stm8_type->type_name, stm8_type->ram_size, stm8_type->flash_min_size, stm8_type->flash_max_size,
+            stm8_type->eeprom_base_address, stm8_type->eeprom_min_size, stm8_type->eeprom_max_size,
+            stm8_type->flash_block_size);
+
+          if (!autodetect_device->name) {
+            autodetect_device->name = stm8_type->type_name;
+            autodetect_device->flash_size = stm8_type->flash_min_size;
+            autodetect_device->flash_start = FLASH_START;
+            autodetect_device->flash_block_size = stm8_type->flash_block_size;
+            autodetect_device->eeprom_size = stm8_type->eeprom_min_size;
+            autodetect_device->eeprom_start = stm8_type->eeprom_base_address;
+            autodetect_device->ram_start = RAM_START;
+            autodetect_device->ram_size = stm8_type->ram_size;
+            autodetect_device->read_out_protection_mode = stm8_type->read_out_protection_mode;
+            autodetect_device->regs = stm8_regs[stm8_type->regset];
+          }
+          else { // we have a new match, check for conflicting match
+            if ((stm8_type->flash_block_size != autodetect_device->flash_block_size) ||
+                ((stm8_type->eeprom_base_address != autodetect_device->eeprom_start))) {
+              return -3;
+            }
+            else {
+              // TODO : update autodetect_device to return the smallest flash size/eeprom size/ram size
+            }
+          }
+        }
+      } while (num_matches > 0);
+    }
+  } // for
+
+  DEBUG_PRINT( "autodetection completed\n");
+
+  if (!autodetect_device->name) {
+    return -2; // no match found
+  }
+
+  return 0;
+}

--- a/autodetect.h
+++ b/autodetect.h
@@ -1,0 +1,10 @@
+#ifndef __AUTODETECT_H
+#define __AUTODETECT_H
+
+#include "pgm.h"
+
+// return 0 = success, -1 = ROP active, -2 no match, -3 conflicting matches found, -4 comms error
+int autodetect(programmer_t *pgm, stm8_device_t *autodetect_part);
+
+#endif
+

--- a/main.c
+++ b/main.c
@@ -19,6 +19,8 @@
 #include "ihex.h"
 #include "srec.h"
 
+#include "autodetect.h"
+
 typedef enum {
     INTEL_HEX = 0,
     MOTOROLA_S_RECORD,
@@ -38,7 +40,8 @@ extern int optreset;
 #define VERSION_NOTES ""
 
 programmer_t pgms[] = {
-	{ 	"stlink",
+	{
+		"stlink",
 		STLinkV1,
 		0x0483, // USB vid
 		0x3744, // USB pid
@@ -54,7 +57,7 @@ programmer_t pgms[] = {
 		0x0483,
 		0x3748,
 		stlink2_open,
-		stlink_close,
+		stlink2_close,
 		stlink2_srst,
 		stlink2_swim_read_range,
 		stlink2_swim_write_range,
@@ -65,7 +68,7 @@ programmer_t pgms[] = {
 		0x0483,
 		0x374b,
 		stlink2_open,
-		stlink_close,
+		stlink2_close,
 		stlink2_srst,
 		stlink2_swim_read_range,
 		stlink2_swim_write_range,
@@ -76,7 +79,7 @@ programmer_t pgms[] = {
 		0x0483,
 		0x374f,
 		stlink2_open,
-		stlink_close,
+		stlink2_close,
 		stlink2_srst,
 		stlink2_swim_read_range,
 		stlink2_swim_write_range,
@@ -206,7 +209,6 @@ bool usb_init(programmer_t *pgm, bool pgm_serialno_specified, char *pgm_serialno
 	}
 
 	if(numOfProgrammers > 1 || pgm_serialno_specified){
-
 		// no serialno given
 		if(!pgm_serialno_specified) {
 			fprintf(stderr, "WARNING: More than one programmer found but no serial number given. Programmer 1 will be used:\n");
@@ -256,9 +258,6 @@ bool usb_init(programmer_t *pgm, bool pgm_serialno_specified, char *pgm_serialno
 		pgm->dev_handle = libusb_open_device_with_vid_pid(ctx, pgm->usb_vid, pgm->usb_pid);
 	}
 
-
-
-
 	pgm->ctx = ctx;
 	if (!pgm->dev_handle) spawn_error("Could not open USB device.");
 	// assert(pgm->dev_handle);
@@ -304,14 +303,19 @@ int main(int argc, char **argv) {
 		pgm_specified = false,
 		pgm_serialno_specified = false,
 		part_specified = false,
-        bytes_count_specified = false;
+		bytes_count_specified = false,
+		part_auto_detection = false; 
 	memtype_t memtype = FLASH;
 	const char * port = NULL;
 	int i;
 	programmer_t *pgm = NULL;
 	const stm8_device_t *part = NULL;
-	while((c = getopt (argc, argv, "r:w:v:nc:S:p:d:s:b:luV")) != (char)-1) {
+	stm8_device_t autodetect_part;
+	while((c = getopt (argc, argv, "r:w:v:nc:S:p:d:s:b:aluV")) != (char)-1) {
 		switch(c) {
+			case 'a' :
+				part_auto_detection = true;
+				break;
 			case 'c':
 				pgm_specified = true;
 				for(i = 0; pgms[i].name; i++) {
@@ -348,21 +352,21 @@ int main(int argc, char **argv) {
 				action = VERIFY;
 				strcpy(filename, optarg);
 				break;
-                        case 'u':
+			case 'u':
 				action = UNLOCK;
 				start  = 0x4800;
 				memtype = OPT;
 				strcpy(filename, "Workaround");
 				break;
 			case 's':
-                // Start addr is depending on MCU type
+				// Start addr is depending on MCU type
 				if(strcasecmp(optarg, "flash") == 0) {
 					memtype = FLASH;
-                } else if(strcasecmp(optarg, "eeprom") == 0) {
+				} else if(strcasecmp(optarg, "eeprom") == 0) {
 					memtype = EEPROM;
-                } else if(strcasecmp(optarg, "ram") == 0) {
+				} else if(strcasecmp(optarg, "ram") == 0) {
 					memtype = RAM;
-                } else if(strcasecmp(optarg, "opt") == 0) {
+				} else if(strcasecmp(optarg, "opt") == 0) {
 					memtype = OPT;
 				} else {
 					// Start addr is specified explicitely
@@ -374,13 +378,13 @@ int main(int argc, char **argv) {
 				break;
 			case 'b':
 				bytes_count = atoi(optarg);
-                bytes_count_specified = true;
+				bytes_count_specified = true;
 				break;
 			case 'V':
-                                print_version_and_exit( (bool)0);
+				print_version_and_exit( (bool)0);
 				break;
 			case '?':
-                                print_help_and_exit(argv[0], false);
+				print_help_and_exit(argv[0], false);
 			default:
 				print_help_and_exit(argv[0], true);
 		}
@@ -395,6 +399,34 @@ int main(int argc, char **argv) {
 	if(!pgm)
 		spawn_error("No programmer has been specified");
 	pgm->port = port;
+
+
+	// part auto-detection
+	if (part_auto_detection) {
+		int retval;
+
+		// start connection to programmer
+		if(!usb_init(pgm, pgm_serialno_specified, pgm_serialno))
+			spawn_error("Couldn't initialize programmer");
+
+		if(!pgm->open(pgm))
+			spawn_error("Error communicating with MCU. Please check your SWIM connection.");
+
+		retval = autodetect(pgm, &autodetect_part);
+		pgm->reset(pgm);
+		pgm->close(pgm);
+		if (retval) {
+			fprintf(stderr, "auto-detection failed with code %d\n",retval);
+		}
+		else {
+			part_specified = true;
+			part = &autodetect_part;
+			fprintf(stderr, "auto-detection successful\n");
+		}
+		// exit here for test; but it should work to continue now
+		// exit(0);
+	}
+
 	if(part_specified && !part) {
 		fprintf(stderr, "No valid part specified. Use -l to see the list of supported devices.\n");
 		exit(-1);
@@ -472,8 +504,9 @@ int main(int argc, char **argv) {
 		spawn_error("No filename has been specified");
 	if(!action || !start_addr_specified || !strlen(filename))
 		print_help_and_exit(argv[0], true);
+
 	if(!usb_init(pgm, pgm_serialno_specified, pgm_serialno))
-		spawn_error("Couldn't initialize stlink");
+		spawn_error("Couldn't initialize programmer");
 	if(!pgm->open(pgm))
 		spawn_error("Error communicating with MCU. Please check your SWIM connection.");
 

--- a/pgm.h
+++ b/pgm.h
@@ -56,7 +56,7 @@ typedef struct programmer_s {
 	unsigned int out_msg_size; // stlink/stlinkv2
 
 	/* Data for espstlink module. */
-        espstlink_t * espstlink;
+	espstlink_t * espstlink;
 	const char *port;
 } programmer_t;
 

--- a/stlink.c
+++ b/stlink.c
@@ -347,6 +347,8 @@ bool stlink_open(programmer_t *pgm) {
 }
 
 void stlink_close(programmer_t *pgm) {
+	// bit strange that usb_init is done in main, and exit done here..
+	libusb_close(pgm->dev_handle);
 	libusb_exit(pgm->ctx); //close the session
 }
 

--- a/stlinkv2.c
+++ b/stlinkv2.c
@@ -377,6 +377,7 @@ bool stlink2_open(programmer_t *pgm) {
 	// Mask internal interrupt sources, enable access to whole of memory,
 	// prioritize SWIM and stall the CPU.
 	swim_write_byte(pgm, 0xa1, 0x7f80);
+	swim_write_byte(pgm,0x9,0x7F99); // stall CPU & flush
 
 	swim_cmd(pgm, 2, STLINK_SWIM, SWIM_DEASSERT_RESET);
 	usleep(1000);
@@ -397,6 +398,9 @@ void stlink2_srst(programmer_t *pgm) {
 
 void stlink2_close(programmer_t *pgm) {
 	stlink2_cmd(pgm, 2, STLINK_SWIM, SWIM_EXIT);
+	// bit strange that usb_init is done in main, and exit done here..
+	libusb_close(pgm->dev_handle);
+	libusb_exit(pgm->ctx); //close the session
 }
 
 static void swim_write_byte(programmer_t *pgm, unsigned char byte, unsigned int start) {

--- a/stlinkv2.h
+++ b/stlinkv2.h
@@ -5,6 +5,7 @@
 
 bool stlink2_open(programmer_t *pgm);
 void stlink2_srst(programmer_t *pgm);
+void stlink2_close(programmer_t *pgm);
 int stlink2_swim_read_range(programmer_t *pgm, const stm8_device_t *device, unsigned char *buffer, unsigned int start, unsigned int length);
 int stlink2_swim_write_range(programmer_t *pgm, const stm8_device_t *device, unsigned char *buffer, unsigned int start, unsigned int length, const memtype_t memtype);
 

--- a/stm8.c
+++ b/stm8.c
@@ -1,25 +1,6 @@
 #include <stdio.h>
 #include "stm8.h"
 
-#define REGS_STM8S { \
-        .CLK_CKDIVR = 0x50c6,  \
-        .FLASH_PUKR = 0x5062,  \
-        .FLASH_DUKR = 0x5064,  \
-        .FLASH_IAPSR = 0x505f, \
-        .FLASH_CR2 = 0x505b,   \
-        .FLASH_NCR2 = 0x505c,   \
-}
-
-// Note: FLASH_NCR2 not present on stm8l
-#define REGS_STM8L { \
-        .CLK_CKDIVR = 0x50c0,  \
-        .FLASH_PUKR = 0x5052,  \
-        .FLASH_DUKR = 0x5053,  \
-        .FLASH_IAPSR = 0x5054, \
-        .FLASH_CR2 = 0x5051,   \
-        .FLASH_NCR2 = 0x0000,   \
-}
-
 const stm8_device_t stm8_devices[] = {
     {
         .name = "stlux385",
@@ -57,7 +38,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -70,7 +51,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -83,7 +64,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 128*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -96,7 +77,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 4*1024,
         .flash_block_size = 64,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -109,7 +90,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -122,7 +103,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -135,7 +116,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -148,7 +129,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 16*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -161,7 +142,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -174,7 +155,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -187,7 +168,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -200,7 +181,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -213,7 +194,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 128*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S,
         REGS_STM8S
     },
     {
@@ -226,7 +207,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -239,7 +220,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 16*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -252,7 +233,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -265,7 +246,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size = 13,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -278,7 +259,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size = 13,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -291,7 +272,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 16*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -304,7 +285,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -317,7 +298,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size = 13,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -330,7 +311,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size = 13,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -343,7 +324,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size = 9,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0013
         REGS_STM8L
     },
     {
@@ -356,7 +337,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size = 13,
-        .read_out_protection_mode = ROP_STM8L,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -369,7 +350,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -382,7 +363,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size = 13,
-        .read_out_protection_mode = ROP_STM8L,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -395,7 +376,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 64,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -408,7 +389,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 2*1024,
         .flash_block_size = 64,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0013
         REGS_STM8L
     },
     {
@@ -421,7 +402,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 4*1024,
         .flash_block_size = 64,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0013
         REGS_STM8L
     },
     {
@@ -434,7 +415,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0013
         REGS_STM8L
     },
     {
@@ -447,7 +428,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 4*1024,
         .flash_block_size = 64,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -460,7 +441,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -476,7 +457,7 @@ const stm8_device_t stm8_devices[] = {
         // According to user feedback, stm8flash works with 128, but not with 64.
         .flash_block_size = 128,
         .option_bytes_size = 13,
-        .read_out_protection_mode = ROP_STM8L,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -489,7 +470,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size = 13,
-        .read_out_protection_mode = ROP_STM8L,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -502,7 +483,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -515,7 +496,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 16*1024,
         .flash_block_size = 128,
         .option_bytes_size = 13,
-        .read_out_protection_mode = ROP_STM8L,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -528,7 +509,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size = 13,
-        .read_out_protection_mode = ROP_STM8L,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -541,7 +522,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -554,7 +535,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8L, // RM0031
         REGS_STM8L
     },
     {
@@ -567,7 +548,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size = 11,
-        .read_out_protection_mode = ROP_STM8S,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -580,7 +561,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size = 11,
-        .read_out_protection_mode = ROP_STM8S,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -593,7 +574,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size = 15,
-        .read_out_protection_mode = ROP_STM8S,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -606,7 +587,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -619,7 +600,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 4*1024,
         .flash_block_size = 64,
         .option_bytes_size = 11,
-        .read_out_protection_mode = ROP_STM8S,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -632,7 +613,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size = 11,
-        .read_out_protection_mode = ROP_STM8S,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
          REGS_STM8S
     },
     {
@@ -645,7 +626,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 16*1024,
         .flash_block_size = 128,
         .option_bytes_size = 15,
-        .read_out_protection_mode = ROP_STM8S,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -658,7 +639,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size = 15,
-        .read_out_protection_mode = ROP_STM8S,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -671,7 +652,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -684,7 +665,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 128*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -697,7 +678,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -710,7 +691,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -723,7 +704,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 128*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -736,7 +717,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -749,7 +730,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 128*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -762,7 +743,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -775,7 +756,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 128*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -788,7 +769,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -801,7 +782,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -814,7 +795,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -827,7 +808,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 32*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -840,7 +821,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 64*1024,
         .flash_block_size = 128,
         .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -853,7 +834,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 128*1024,
         .flash_block_size = 128,
         .option_bytes_size = 17,
-        .read_out_protection_mode = ROP_STM8S,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {
@@ -866,7 +847,7 @@ const stm8_device_t stm8_devices[] = {
         .flash_size = 8*1024,
         .flash_block_size = 64,
         .option_bytes_size = 11,
-        .read_out_protection_mode = ROP_STM8S,
+        .read_out_protection_mode = ROP_STM8S, // RM0016
         REGS_STM8S
     },
     {

--- a/stm8.h
+++ b/stm8.h
@@ -36,5 +36,24 @@ typedef struct stm8_device {
 
 extern const stm8_device_t stm8_devices[];
 
+#define REGS_STM8S { \
+        .CLK_CKDIVR = 0x50c6,  \
+        .FLASH_PUKR = 0x5062,  \
+        .FLASH_DUKR = 0x5064,  \
+        .FLASH_IAPSR = 0x505f, \
+        .FLASH_CR2 = 0x505b,   \
+        .FLASH_NCR2 = 0x505c,   \
+}
+
+// Note: FLASH_NCR2 not present on stm8l
+#define REGS_STM8L { \
+        .CLK_CKDIVR = 0x50c0,  \
+        .FLASH_PUKR = 0x5052,  \
+        .FLASH_DUKR = 0x5053,  \
+        .FLASH_IAPSR = 0x5054, \
+        .FLASH_CR2 = 0x5051,   \
+        .FLASH_NCR2 = 0x0000,   \
+}
+
 #endif
 


### PR DESCRIPTION
Hi @spth @vdudouyt,
For your consideration, this proposal for a STM8 device auto-detection.
For the moment only device reads are performed for the auto-detection. Based on the device table provided with STVP, it is possible to auto-detect STM8 families, sufficiently, to identify the flash block size, eeprom base address, read-out-protection (S or L), and regs (S or L).
In proposed code the auto-detection is currently added under the -a option, and works instead of the -p option. For instance, this command to perform autodetection only (on STM8S105):
```
./stm8flash -c stlinkv2 -a
STLink: v2, JTAG: v37, SWIM: v7, VID: 8304, PID: 4837
found SP = 0x7ff, assuming ram size = 2K
bootrom is present
found PC = 0x6000 : mcu currently stalled in bootrom
possible match! found STM8S105 with 2048 bytes RAM, flash size between 16384 and 32768, eeprom at 0x4000 with size between 1024 and 1024, flash block size = 128
auto-detection successful
Determine FLASH area
No action has been specified
```
-a option can be combined with existing actions in stm8flash, for example read from flash below on STM8S103. For now it reads/writes the smallest size detected.

```
$ ./stm8flash -c stlinkv2 -a -s flash -r autodetect_flash.bin
STLink: v2, JTAG: v37, SWIM: v7, VID: 8304, PID: 4837
found SP = 0x3ff, assuming ram size = 1K
bootrom not present
found PC = 0x8000 : mcu currently stalled in flash
possible match! found STM8Sx03 with 1024 bytes RAM, flash size between 4096 and 8192, eeprom at 0x4000 with size between 640 and 640, flash block size = 64
auto-detection successful
Determine FLASH area
STLink: v2, JTAG: v37, SWIM: v7, VID: 8304, PID: 4837
Due to its file extension (or lack thereof), "autodetect_flash.bin" is considered as RAW BINARY format!
Reading 4096 bytes at 0x8000... OK
Bytes received: 4096

```

The changes are essentially in autodetect.* 
in main.c the auto-detection stage is added.
in stlinkv2.c the open() function was modified to effectively stall the CPU (there was a comment that CPU was stalled, but in reality only SWIM_DM was activated). For the auto-detection it was more convenient to have the CPU stalled immediately after reset, because then SP points to the top of RAM, and ram size can be deduced.
In stm8.c I adapted the ROP_UNKNOWN read_out_protection_mode values based on the datasheets/reference manuals. For instance there is a single reference manual for STM8AF and STM8S, so obviously these devices have the same handling for ROP.
The other changed files are cosmetic changes.

PR is not ready for merging yet, but I'm interested to know your results on other devices, and happy to take comments. 
Thanks for testing & reviewing!
