### PR TITLE
stlinkv2: fix the flash programming mode selection

### DIFF
--- a/stlinkv2.c
+++ b/stlinkv2.c
@@ -501,19 +501,27 @@ int stlink2_swim_write_range(programmer_t *pgm, const stm8_device_t *device, uns
 			if (ONLY_WRITE_DIFFS && !memcmp(current + i, buffer + i, device->flash_block_size)) {
 				DEBUG_PRINT("no change 0x%04x to 0x%04x\n", start + i, start + i + device->flash_block_size);
 			} else {
-				int prgmode = 0x10;
-				// BUG HERE : can read beyond buffer[] array boundary, because buffer is not always a multiple of flash_block_size
+				int prgmode;
+				/*
+				 * Use fast block programming (prgmode = 0x10) only if we have
+				 * read the flash block and verified that it is empty (all its
+				 * bytes are 0x00).
+				 */
+#if ONLY_WRITE_DIFFS
+				prgmode = 0x10;
 				for (int j = 0; j < device->flash_block_size; j++) {
-					if (buffer[i + j]) {
+					if (current[i + j]) {
 						prgmode = 0x01;
 						break;
 					}
 				}
+#else
+				prgmode = 0x01;
+#endif
 
 				DEBUG_PRINT("%swrite 0x%04x to 0x%04x\n", (prgmode == 0x10 ? "fast " : ""), start + i, start + i + device->flash_block_size);
 
 				if (memtype == FLASH || memtype == EEPROM) {
-					// Standard block programming mode
 					swim_write_byte(pgm, prgmode, device->regs.FLASH_CR2);
 					if(device->regs.FLASH_NCR2 != 0) {
 						swim_write_byte(pgm, ~prgmode, device->regs.FLASH_NCR2);


### PR DESCRIPTION
For writing a flash block, we can select fast block programming or standard block programming.

Fast block programming works only if the block has been erased before, i.e. if all of its bytes are 0x00.

The current implementation checks the bytes in the "buffer" array. If all bytes of our block are 0x00, it uses fast mode. Otherwise, standard mode is selected. This is wrong: buffer contains the data that we want to write, not the data that is currently in the flash block.

I spotted this problem when I uploaded a file with large areas of 0x00 bytes. For a block within such a 0x00 area, fast block programming was selected although the block in flash was not empty. The block with 0x00s was not written, the resulting flash image was corrupt.

Reproducing the issue is as simple as

stm8flash -c stlinkv2 -p stm8l151c8 -s flash -w <any non-emtpy file>
dd if=/dev/zero of=./only00 bs=1k count=32
stm8flash -c stlinkv2 -p stm8l151c8 -s flash -w ./only00
stm8flash -c stlinkv2 -p stm8l151c8 -s flash -v ./only00
Verification returns an error.

Fix this by checking the current content of the flash block instead of the data that we want to upload. This works only if we have read the block from flash before. If we haven't read the block, we have default to standard block programming.

With this patch applied, the test above results in a successful verification.