### PR TITLE
stm8: support unlock for stm8l151?8

### DIFF
--- a/stm8.c
+++ b/stm8.c
@@ -503,8 +503,8 @@ const stm8_device_t stm8_devices[] = {
         .flash_start = 0x8000,
         .flash_size = 64*1024,
         .flash_block_size = 128,
-        .option_bytes_size =0,
-        .read_out_protection_mode = ROP_UNKNOWN,
+        .option_bytes_size = 13,
+        .read_out_protection_mode = ROP_STM8L,
         REGS_STM8L
     },
     {


### PR DESCRIPTION
stm8l151?8 chipsets have 13 option bytes and use the stm8l mechanism to reset the readout protection.