### PR TITLE
ensure programmer serial number string is properly zero terminated.

### DIFF
--- a/main.c
+++ b/main.c
@@ -177,7 +177,7 @@ bool usb_init(programmer_t *pgm, bool pgm_serialno_specified, char *pgm_serialno
 	char vendor[32];
 	char device[32];
 	char serialno[32];
-	char serialno_hex[64];
+	char serialno_hex[64 + 1] = {0};
 
 
 	int r;
@@ -233,7 +233,8 @@ bool usb_init(programmer_t *pgm, bool pgm_serialno_specified, char *pgm_serialno
 
 				libusb_get_string_descriptor_ascii(tempHandle, desc.iManufacturer, (unsigned char*)vendor, sizeof(vendor));
 				libusb_get_string_descriptor_ascii(tempHandle, desc.iProduct, (unsigned char*)device, sizeof(device));
-				const int serialno_length = libusb_get_string_descriptor_ascii(tempHandle, desc.iSerialNumber, (unsigned char*)serialno, sizeof(serialno));
+				int serialno_length = libusb_get_string_descriptor_ascii(tempHandle, desc.iSerialNumber, (unsigned char*)serialno, sizeof(serialno));
+				if (serialno_length > 32) serialno_length = 32;
 				serialno_to_hex(serialno, serialno_length, serialno_hex);
 
 				// print programmer data if no serial number specified


### PR DESCRIPTION
I'm working on a setup with two ST Link v2 programmers, so I have to select them using their serial numbers.
Initially I was using the stm8flash binary from platformio. This worked fine. But after building from the most recent master, I got this error message:

    $ stm8flash -S "523F6E06663F56493946103F" -c stlinkv2 -p "stm8s103?3" -s flash -w ki.hex
    Determine FLASH area
    ERROR: No programmer with serial number 523F6E06663F56493946103F found.
    Couldn't initialize stlink

I added some debug output to check the comparison of the serial numbers:

    fprintf(stdout, "a=\"%s\" b=\"%s\"\n", serialno_hex, pgm_serialno);

Which gave this output:

    $ stm8flash -S 523F6E06663F56493946103F -c stlinkv2 -p "stm8s103?3" -s flash -w ki.hex
    Determine FLASH area
    a="523F6E06663F56493946103FX/��" b="523F6E06663F56493946103F"
    a="373F6B064D56343143160843X/��" b="523F6E06663F56493946103F"
    ERROR: No programmer with serial number 523F6E06663F56493946103F found.
    Couldn't initialize stlink

Looking at the code, this makes sense. The string is never actually initialized with zeros. So I added the initialization, as well as a check to make sure at least the final zero byte is never overwritten.

This should fix the problem, at least as long as all programmer serials have the same length.

With these changes I can now successfully flash the target:

    $ stm8flash -S 523F6E06663F56493946103F -c stlinkv2 -p "stm8s103?3" -s flash -w ki.hex
    Determine FLASH area
    a="523F6E06663F56493946103F" b="523F6E06663F56493946103F"
    STLink: v2, JTAG: v29, SWIM: v7, VID: 8304, PID: 4837
    Due to its file extension (or lack thereof), "ki.hex" is considered as INTEL HEX format!
    8109 bytes at 0x8000... OK
    Bytes written: 8109

Hope this helps :smiley_cat: 