### PR TITLE
Update espstlink code

### DIFF
--- a/espstlink.c
+++ b/espstlink.c
@@ -145,22 +145,24 @@ int espstlink_swim_write_range(programmer_t *pgm, const stm8_device_t *device,
 
     for (; i < length; i += device->flash_block_size) {
       // Write one block at a time.
-      if (memtype == FLASH || memtype == EEPROM) {
-        // Block programming mode
-        espstlink_write_byte(pgm, prgmode, device->regs.FLASH_CR2);
-        if(device->regs.FLASH_NCR2 != 0) {
-          espstlink_write_byte(pgm, ~prgmode, device->regs.FLASH_NCR2);
+      if (memcmp(current + i, buffer + i, device->flash_block_size)) {
+        if (memtype == FLASH || memtype == EEPROM) {
+          // Block programming mode
+          espstlink_write_byte(pgm, prgmode, device->regs.FLASH_CR2);
+          if(device->regs.FLASH_NCR2 != 0) {
+            espstlink_write_byte(pgm, ~prgmode, device->regs.FLASH_NCR2);
+          }
         }
-      }
 
-      if (!espstlink_swim_write(pgm->espstlink, buffer + i, start + i,
-                                device->flash_block_size))
-        return i;
+        if (!espstlink_swim_write(pgm->espstlink, buffer + i, start + i,
+                                  device->flash_block_size))
+          return i;
 
-      if (memtype == FLASH || memtype == EEPROM) {
-        // t_prog per the datasheets is 6ms typ, 6.6ms max
-        usleep(6000);
-        espstlink_wait_until_transfer_completes(pgm, device);
+        if (memtype == FLASH || memtype == EEPROM) {
+          // t_prog per the datasheets is 6ms typ, 6.6ms max
+          usleep(6000);
+          espstlink_wait_until_transfer_completes(pgm, device);
+        }
       }
     }
   }

--- a/espstlink.c
+++ b/espstlink.c
@@ -130,9 +130,11 @@ int espstlink_swim_write_range(programmer_t *pgm, const stm8_device_t *device,
       return i;
     i += current_size;
 
-    espstlink_wait_until_transfer_completes(pgm, device);
-    // TODO: Check the WR_PG_DIS bit in FLASH_IAPSR to verify if the block you
-    // attempted to program was not write protected (optional)
+    if (memtype == FLASH || memtype == EEPROM) {
+      // t_prog per the datasheets is 6ms typ, 6.6ms max
+      usleep(6000);
+      espstlink_wait_until_transfer_completes(pgm, device);
+    }
   }
   return i;
 }

--- a/espstlink.c
+++ b/espstlink.c
@@ -120,10 +120,11 @@ int espstlink_swim_write_range(programmer_t *pgm, const stm8_device_t *device,
 
   size_t i = 0;
   for (; i < length;) {
-    // Write one block (128 bytes) at a time.
+    // Write one block at a time.
     int current_size = length - i;
-    if (current_size > 128)
-      current_size = 128;
+    if (current_size > device->flash_block_size)
+      current_size = device->flash_block_size;
+
     if (!espstlink_swim_write(pgm->espstlink, buffer + i, start + i,
                               current_size))
       return i;

--- a/espstlink.c
+++ b/espstlink.c
@@ -158,6 +158,14 @@ int espstlink_swim_write_range(programmer_t *pgm, const stm8_device_t *device,
       }
     }
   }
+
+  if (memtype == FLASH || memtype == EEPROM || memtype == OPT) {
+      // Reset DUL and PUL in IAPSR to disable flash and data writes.
+      int iapsr = espstlink_read_byte(pgm, device->regs.FLASH_IAPSR);
+      if (iapsr != -1)
+        espstlink_write_byte(pgm, iapsr & (~0x0a), device->regs.FLASH_IAPSR);
+  }
+
   return i;
 }
 


### PR DESCRIPTION
The espstlink code did not support low-density chips (with 64 byte flash block size), did not support flashing more than one block (flag in FLASH_CR2 must be set before each block), and did not support handle data that is not an exactly multiple of the flash block size.

These changes make the espstlink code behave much more like the stlinkv2 code.