### PR TITLE
makefile: honor `PKG_CONFIG` variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 #   - Windows (e.g. mingw-w64-x86 with libusb1.0)
 
 
+PKG_CONFIG ?= pkg-config
 PLATFORM=$(shell uname -s)
 DEBUG=0
 
@@ -24,16 +25,16 @@ endif
 BASE_CFLAGS += --std=gnu99 --pedantic -Wall
 
 ifeq ($(PLATFORM),Linux)
-	LIBS = `pkg-config --libs libusb-1.0`
-	LIBUSB_CFLAGS = `pkg-config --cflags libusb-1.0`
+	LIBS = `$(PKG_CONFIG) --libs libusb-1.0`
+	LIBUSB_CFLAGS = `$(PKG_CONFIG) --cflags libusb-1.0`
 else ifeq ($(PLATFORM),Darwin)
-	LIBS = $(shell pkg-config --libs libusb-1.0)
-	LIBUSB_CFLAGS = $(shell pkg-config --cflags libusb-1.0)
+	LIBS = $(shell $(PKG_CONFIG) --libs libusb-1.0)
+	LIBUSB_CFLAGS = $(shell $(PKG_CONFIG) --cflags libusb-1.0)
 	#MacOSSDK=$(shell xcrun --show-sdk-path)
 	#BASE_CFLAGS += -I$(MacOSSDK)/usr/include/ -I$(MacOSSDK)/usr/include/sys -I$(MacOSSDK)/usr/include/machine
 else ifeq ($(PLATFORM),FreeBSD)
-	LIBS = `pkg-config --libs libusb-1.0`
-	LIBUSB_CFLAGS = `pkg-config --cflags libusb-1.0`
+	LIBS = `$(PKG_CONFIG) --libs libusb-1.0`
+	LIBUSB_CFLAGS = `$(PKG_CONFIG) --cflags libusb-1.0`
 else
 # 	Generic case is Windows
 


### PR DESCRIPTION
this is particularly useful when stm8flash is to be run on a different architecture than the machine that's building it (i.e. cross-compiling), as this often requires using a different `pkg-config` than the build machine would use when targeting its own architecture. build systems like [autotools](https://gitlab.freedesktop.org/pkg-config/pkg-config/-/blob/master/README?ref_type=heads&plain=1#L14), [cmake](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Help/release/3.1.rst?ref_type=heads&plain=1#L245) and [meson](https://github.com/mesonbuild/meson/blob/master/docs/markdown/Release-notes-for-0.37.0.md#overriding-more-binaries-with-environment-variables) support `PKG_CONFIG`, but Make is low-level enough that it has to be implemented manually.

this PR is based on the [patch](https://github.com/NixOS/nixpkgs/blob/9d75eab85f656363cbaf13cd5ed29ba8625f0fb0/pkgs/by-name/st/stm8flash/package.nix#L32) that NixOS applies to its stm8flash package.